### PR TITLE
updated nixcrpkgs and musl

### DIFF
--- a/nix/nixcrpkgs/README.md
+++ b/nix/nixcrpkgs/README.md
@@ -17,9 +17,11 @@ Packages collection (Nixpkgs)][nixpkgs].
 ## Features
 
 - Supported target platforms:
-  - Windows (32-bit or 64-bit) using [mingw-w64](https://mingw-w64.org/) and [GCC](https://gcc.gnu.org/) 6.3.0
-  - Linux (32-bit, 64-bit, and ARM) using [musl](https://www.musl-libc.org/) and [GCC](https://gcc.gnu.org/) 6.3.0
-  - macOS using [Clang](https://clang.llvm.org/) 5.0.0
+  - Windows (32-bit or 64-bit) using [mingw-w64](https://mingw-w64.org/)
+    and [GCC](https://gcc.gnu.org/) 8.2.0
+  - Linux (32-bit, 64-bit, and ARM) using [musl](https://www.musl-libc.org/)
+    and [GCC](https://gcc.gnu.org/) 8.2.0
+  - macOS using [Clang](https://clang.llvm.org/) 7.0.1
 - Supported languages for cross-compiling:
   - C
   - C++
@@ -33,7 +35,7 @@ Packages collection (Nixpkgs)][nixpkgs].
   - [GNU Bash](https://www.gnu.org/software/bash/)
   - [Ruby](https://www.ruby-lang.org/)
 - Notable supported libraries:
-  - [Qt](https://www.qt.io/) 5.9.6
+  - [Qt](https://www.qt.io/) 5.12.1
   - [libusb](https://libusb.info/)
   - [libusbp](https://github.com/pololu/libusbp)
   - [Windows API](https://en.wikipedia.org/wiki/Windows_API) (thanks to mingw-w64)
@@ -46,10 +48,10 @@ instructions on the [Nix website][nix].
 
 Next, run `df -h` to make sure you have enough disk space.
 
-- The filesystem that holds `/nix` should have several gigabytes of free
-space.  Each GCC cross-compiler takes about 300 MB while each Qt installation
-takes about 800 MB.
-- The filesystem that holds `/tmp` should have at least 4 gigabytes of free
+- The filesystem that holds `/nix` should have many gigabytes of free
+space.  Each cross-compiler can take about 1 GB while each Qt installation
+takes about 500 MB.
+- The filesystem that holds `/tmp` should have at least 4 GB of free
 space, which will be needed while building cross-compilers.  If that is not the
 case on your system, you can set the `TMPDIR` environment variable to tell
 `nix-build` to perform its builds in a different directory on a filesystem with
@@ -138,14 +140,41 @@ Each build recipe in nixcrpkgs specifies a version number for the software that 
 6) Once things are working, consider publishing your work on Github so others can benefit from what you figured out.
 
 
-## Maintaining the nixcrpkgs system
+## Freeing disk space
 
 You should occasionally run `nix-collect-garbage` to remove items that are no
 longer needed and reclaim your disk space.  However, note that Nix will
 typically remove all of your cross compilers and libraries when you run this
-command, so be prepared to do a lengthy mass rebuild.  The Nix manual has more
+command, which could require you to do a length mass rebuild the next time you
+want to build your software.
+
+There is a method you can use to prevent Nix from garbage collecting the most
+important items used by nixcrpkgs.  First of all, edit or create your [nix.conf]
+file and add this line to it:
+
+    keep-outputs = true
+
+Now run this command from the nixcrpkgs directory (you'll need Ruby installed):
+
+    ./manage gcroots
+
+This makes a symbolic link in the nixcrpkgs directory called `gcroots.drv`,
+which points to a derivation (a compiled recipe for building some software) in
+the Nix store which depends on all the derivations that are most
+important for nixcrpkgs.  As long as `gcroots.drv` remains in place, those
+derivations and their outputs cannot be garbage collected.
+
+In the future, if you update nixcrpkgs and then run the command to update
+`gcroots.drv`, then items used by the old version of nixcrpkgs that are no
+longer needed can be garbage collected.  You can also simply delete
+`gcroots.drv` if you want to garbage collect everything needed by nixcrpkgs.
+
+The Nix manual has more
 information about [Nix garbage
 collection](http://nixos.org/nix/manual/#sec-garbage-collection).
+
+
+## Updating recipes
 
 You should occasionally run `nix-channel --update` to update to the latest
 version of Nixpkgs.  However, when doing this, be aware that the new version of
@@ -173,3 +202,4 @@ to use your forked versions.
 [osxcross]: https://github.com/tpoechtrager/osxcross
 [musl-cross-make]: https://github.com/richfelker/musl-cross-make
 [musl_nix_arm]: https://github.com/filleduchaos/musl_nix_arm
+[nix.conf]: https://nixos.org/nix/manual/#sec-conf-file

--- a/nix/nixcrpkgs/default.nix
+++ b/nix/nixcrpkgs/default.nix
@@ -1,3 +1,4 @@
 import ./top.nix {
   nixpkgs = import <nixpkgs> { };
+  osx_sdk = ./macos/MacOSX.sdk.tar.xz;
 }

--- a/nix/nixcrpkgs/default.nix
+++ b/nix/nixcrpkgs/default.nix
@@ -1,4 +1,3 @@
 import ./top.nix {
-  nixpkgs = import <nixpkgs> {};
-  osx_sdk = ./macos/MacOSX.sdk.tar.xz;
+  nixpkgs = import <nixpkgs> { };
 }

--- a/nix/nixcrpkgs/file_builder.sh
+++ b/nix/nixcrpkgs/file_builder.sh
@@ -1,0 +1,3 @@
+source $setup
+
+echo "$contents" > $out

--- a/nix/nixcrpkgs/linux/binutils/default.nix
+++ b/nix/nixcrpkgs/linux/binutils/default.nix
@@ -1,20 +1,21 @@
+# We cannot use binutils 2.31 because then we get a segmentation fault in our
+# hello world program, which comes from static_init_tls() in Musl 1.1.20.
+
 { native, host }:
 
 native.make_derivation rec {
   name = "binutils-${version}-${host}";
 
-  version = "2.27";
+  version = "2.30";
 
   src = native.nixpkgs.fetchurl {
-    url = "mirror://gnu/binutils/binutils-${version}.tar.bz2";
-    sha256 = "125clslv17xh1sab74343fg6v31msavpmaa1c1394zsqa773g5rn";
+    url = "mirror://gnu/binutils/binutils-${version}.tar.xz";
+    sha256 = "1rhshw4m5m2pjz8g15hpiwhp52kn0pj0b5dxy0v7lwigmspbhikf";
   };
 
   patches = [
     ./deterministic.patch
   ];
-
-  native_inputs = [ native.nixpkgs.bison native.nixpkgs.zlib ];
 
   configure_flags =
     "--target=${host} " +

--- a/nix/nixcrpkgs/linux/default.nix
+++ b/nix/nixcrpkgs/linux/default.nix
@@ -4,12 +4,6 @@ let
 
   host = "${arch}-linux-musleabi";
 
-  os = "linux";
-
-  compiler = "gcc";
-
-  exe_suffix = "";
-
   binutils = import ./binutils { inherit native host; };
 
   linux_arch =
@@ -21,10 +15,10 @@ let
   headers = native.make_derivation rec {
     name = "linux-headers-${linux_arch}-${version}";
     inherit linux_arch;
-    version = "4.4.10";
+    version = "4.18.17";
     src = nixpkgs.fetchurl {
       url = "https://cdn.kernel.org/pub/linux/kernel/v4.x/linux-${version}.tar.xz";
-      sha256 = "1kpjvvd9q9wwr3314q5ymvxii4dv2d27295bzly225wlc552xhja";
+      sha256 = "0353ns09i5y0fcygvly20z0qrp6gcqd453186ihm4r7ajgh43bz2";
     };
     builder = ./headers_builder.sh;
   };
@@ -35,43 +29,46 @@ let
 
   license = native.make_derivation {
     name = "linux-license";
-    inherit (gcc) musl_src gcc_src;
+    musl_src = gcc.musl_src;
+    gcc_src = gcc.src;
     linux_src = headers.src;
     builder = ./license_builder.sh;
   };
 
   global_license_set = { _global = license; };
 
-  cmake_toolchain = import ../cmake_toolchain {
-    cmake_system_name = "Linux";
-    inherit nixpkgs host;
-  };
-
-  crossenv = {
+  crossenv = rec {
     is_cross = true;
 
-    # Build tools available on the PATH for every derivation.
-    default_native_inputs = native.default_native_inputs ++
-      [ gcc binutils native.pkgconf native.wrappers ];
+    # Target info.
+    inherit host arch;
+    compiler = "gcc";
+    exe_suffix = "";
+    os = "linux";
+    cmake_system = "Linux";
+    meson_system = "linux";
+    meson_cpu_family =
+      if arch == "i686" then "x86"
+      else if arch == "x86_64" then "x86_64"
+      else if arch == "armv6" || arch == "armv7" then "arm"
+      else if arch == "aarch64" then "aarch64"
+      else throw "not sure what meson_cpu_family code to use";
+    meson_cpu = arch;
 
-    # Target info environment variables.
-    inherit host arch os compiler exe_suffix;
-
-    # CMake toolchain file.
-    inherit cmake_toolchain;
-
-    # A wide variety of programs and build tools.
-    inherit nixpkgs;
-
-    # Some native build tools made by nixcrpkgs.
-    inherit native;
+    # Build tools.
+    inherit nixpkgs native;
+    wrappers = import ../wrappers crossenv;
 
     # License information that should be shipped with any software
     # compiled by this environment.
     inherit global_license_set;
 
-    # Make it easy to refer to the build tools.
+    # Handy shortcuts.
     inherit headers gcc binutils;
+
+    # Build tools available on the PATH for every derivation.
+    default_native_inputs = native.default_native_inputs ++
+      [ gcc binutils wrappers ];
 
     make_derivation = import ../make_derivation.nix crossenv;
   };

--- a/nix/nixcrpkgs/linux/gcc/builder.sh
+++ b/nix/nixcrpkgs/linux/gcc/builder.sh
@@ -1,9 +1,9 @@
 source $setup
 
-tar -xf $gcc_src
+tar -xf $src
 mv gcc-* gcc
 cd gcc
-for patch in $gcc_patches; do
+for patch in $patches; do
   echo applying patch $patch
   patch -p1 -i $patch
 done

--- a/nix/nixcrpkgs/linux/gcc/default.nix
+++ b/nix/nixcrpkgs/linux/gcc/default.nix
@@ -2,42 +2,41 @@
 
 let
   nixpkgs = native.nixpkgs;
-  isl = nixpkgs.isl_0_14;
+  isl = nixpkgs.isl;
   inherit (nixpkgs) stdenv lib fetchurl;
   inherit (nixpkgs) gmp libmpc libelf mpfr zlib;
 in
 
 native.make_derivation rec {
-  name = "gcc-${gcc_version}-${host}";
+  name = "gcc-${version}-${host}";
 
-  gcc_version = "6.3.0";
-  gcc_src = fetchurl {
-    url = "mirror://gnu/gcc/gcc-${gcc_version}/gcc-${gcc_version}.tar.bz2";
-    sha256 = "17xjz30jb65hcf714vn9gcxvrrji8j20xm7n33qg1ywhyzryfsph";
+  version = "8.2.0";
+  src = fetchurl {
+    url = "mirror://gnu/gcc/gcc-${version}/gcc-${version}.tar.xz";
+    sha256 = "10007smilswiiv2ymazr3b6x2i933c0ycxrr529zh4r6p823qv0r";
   };
 
-  musl_version = "1.1.16";
+  musl_version = "1.1.20";
   musl_src = nixpkgs.fetchurl {
     url = "https://www.musl-libc.org/releases/musl-${musl_version}.tar.gz";
-    sha256 = "048h0w4yjyza4h05bkc6dpwg3hq6l03na46g0q1ha8fpwnjqawck";
+    sha256 = "0q8dsjxl41dccscv9a0r78bs7jap57mn4mni5pwbbip6s1qqggj4";
   };
 
   inherit host headers;
 
   builder = ./builder.sh;
 
-  gcc_patches = [
-    # These patches are from nixpkgs.
-    ./use-source-date-epoch.patch
+  patches = [
+    # This patch is from nixpkgs.
     ./libstdc++-target.patch
 
     # Without this, we cannot build a simple hello world program for ARM.
     # See https://gcc.gnu.org/bugzilla/show_bug.cgi?id=31798
     ./link_gcc_c_sequence_spec.patch
 
-    # Fix a compiler error in GCC's ubsan.c: ISO C++ forbids comparison
-    # between pointer and integer.
-    ./ubsan.patch
+    # Fix compilation errors about missing ISL function declarations.
+    # https://gcc.gnu.org/git/?p=gcc.git;a=patch;h=05103aed1d34b5ca07c9a70c95a7cb1d47e22c47
+    ./isl-headers.patch
   ];
 
   native_inputs = [ binutils ];

--- a/nix/nixcrpkgs/linux/gcc/default.nix
+++ b/nix/nixcrpkgs/linux/gcc/default.nix
@@ -16,10 +16,10 @@ native.make_derivation rec {
     sha256 = "10007smilswiiv2ymazr3b6x2i933c0ycxrr529zh4r6p823qv0r";
   };
 
-  musl_version = "1.1.20";
+  musl_version = "1.1.24";
   musl_src = nixpkgs.fetchurl {
     url = "https://www.musl-libc.org/releases/musl-${musl_version}.tar.gz";
-    sha256 = "0q8dsjxl41dccscv9a0r78bs7jap57mn4mni5pwbbip6s1qqggj4";
+    sha256 = "18r2a00k82hz0mqdvgm7crzc7305l36109c0j9yjmkxj2alcjw0k";
   };
 
   inherit host headers;

--- a/nix/nixcrpkgs/linux/gcc/isl-headers.patch
+++ b/nix/nixcrpkgs/linux/gcc/isl-headers.patch
@@ -1,0 +1,11 @@
+--- a/gcc/graphite.h
++++ b/gcc/graphite.h
+@@ -26,6 +26,8 @@
+ #include <isl/options.h>
+ #include <isl/ctx.h>
+ #include <isl/val.h>
++#include <isl/id.h>
++#include <isl/space.h>
+ #include <isl/set.h>
+ #include <isl/union_set.h>
+ #include <isl/map.h>

--- a/nix/nixcrpkgs/linux/gcc/link_gcc_c_sequence_spec.patch
+++ b/nix/nixcrpkgs/linux/gcc/link_gcc_c_sequence_spec.patch
@@ -1,11 +1,12 @@
-diff -ur gcc-6.3.0-orig/gcc/config/gnu-user.h gcc-6.3.0/gcc/config/gnu-user.h
---- gcc-6.3.0-orig/gcc/config/gnu-user.h	2017-08-13 19:03:08.671572528 -0700
-+++ gcc-6.3.0/gcc/config/gnu-user.h	2017-08-13 19:15:00.768588499 -0700
-@@ -123,7 +123,7 @@
+diff -ur gcc-8.2.0-orig/gcc/config/gnu-user.h gcc-8.2.0/gcc/config/gnu-user.h
+--- gcc-8.2.0-orig/gcc/config/gnu-user.h	2019-01-26 19:25:21.590999999 -0800
++++ gcc-8.2.0/gcc/config/gnu-user.h	2019-01-26 19:26:05.910999999 -0800
+@@ -138,8 +138,7 @@
  
  #undef LINK_GCC_C_SEQUENCE_SPEC
  #define LINK_GCC_C_SEQUENCE_SPEC \
--  "%{static:--start-group} %G %L %{static:--end-group}%{!static:%G}"
+-  "%{static|static-pie:--start-group} %G %L \
+-   %{static|static-pie:--end-group}%{!static:%{!static-pie:%G}}"
 +  "--start-group %G %L --end-group"
  
  /* Use --as-needed -lgcc_s for eh support.  */

--- a/nix/nixcrpkgs/macos/clang.patch
+++ b/nix/nixcrpkgs/macos/clang.patch
@@ -1,0 +1,107 @@
+diff -ur cfe-7.0.1.src-orig/lib/Driver/ToolChains/Darwin.cpp cfe-7.0.1.src/lib/Driver/ToolChains/Darwin.cpp
+--- cfe-7.0.1.src-orig/lib/Driver/ToolChains/Darwin.cpp	2018-12-29 19:48:00.045000000 -0800
++++ cfe-7.0.1.src/lib/Driver/ToolChains/Darwin.cpp	2019-01-11 19:46:30.318000999 -0800
+@@ -21,6 +21,7 @@
+ #include "llvm/ADT/StringSwitch.h"
+ #include "llvm/Option/ArgList.h"
+ #include "llvm/Support/Path.h"
++#include "llvm/Support/Process.h"
+ #include "llvm/Support/ScopedPrinter.h"
+ #include "llvm/Support/TargetParser.h"
+ #include <cstdlib> // ::getenv
+@@ -237,23 +238,6 @@
+     }
+   }
+ 
+-  // Use -lto_library option to specify the libLTO.dylib path. Try to find
+-  // it in clang installed libraries. ld64 will only look at this argument
+-  // when it actually uses LTO, so libLTO.dylib only needs to exist at link
+-  // time if ld64 decides that it needs to use LTO.
+-  // Since this is passed unconditionally, ld64 will never look for libLTO.dylib
+-  // next to it. That's ok since ld64 using a libLTO.dylib not matching the
+-  // clang version won't work anyways.
+-  if (Version[0] >= 133) {
+-    // Search for libLTO in <InstalledDir>/../lib/libLTO.dylib
+-    StringRef P = llvm::sys::path::parent_path(D.Dir);
+-    SmallString<128> LibLTOPath(P);
+-    llvm::sys::path::append(LibLTOPath, "lib");
+-    llvm::sys::path::append(LibLTOPath, "libLTO.dylib");
+-    CmdArgs.push_back("-lto_library");
+-    CmdArgs.push_back(C.getArgs().MakeArgString(LibLTOPath));
+-  }
+-
+   // ld64 version 262 and above run the deduplicate pass by default.
+   if (Version[0] >= 262 && shouldLinkerNotDedup(C.getJobs().empty(), Args))
+     CmdArgs.push_back("-no_deduplicate");
+@@ -919,7 +903,17 @@
+ void MachO::AddLinkRuntimeLib(const ArgList &Args, ArgStringList &CmdArgs,
+                               StringRef DarwinLibName,
+                               RuntimeLinkOptions Opts) const {
+-  SmallString<128> Dir(getDriver().ResourceDir);
++  std::string rtPath;
++  if (Optional<std::string> rtPathValue =
++    llvm::sys::Process::GetEnv("COMPILER_RT_PATH")) {
++    rtPath = *rtPathValue;
++  }
++  else {
++    rtPath = getDriver().ResourceDir;
++  }
++
++  SmallString<128> Dir(rtPath);
++
+   llvm::sys::path::append(
+       Dir, "lib", (Opts & RLO_IsEmbedded) ? "macho_embedded" : "darwin");
+ 
+diff -ur cfe-7.0.1.src-orig/lib/Driver/ToolChains/Gnu.cpp cfe-7.0.1.src/lib/Driver/ToolChains/Gnu.cpp
+--- cfe-7.0.1.src-orig/lib/Driver/ToolChains/Gnu.cpp	2018-12-29 19:48:00.045000000 -0800
++++ cfe-7.0.1.src/lib/Driver/ToolChains/Gnu.cpp	2019-01-11 18:17:51.586000999 -0800
+@@ -382,10 +382,6 @@
+       CmdArgs.push_back("-export-dynamic");
+ 
+     if (!Args.hasArg(options::OPT_shared)) {
+-      const std::string Loader =
+-          D.DyldPrefix + ToolChain.getDynamicLinker(Args);
+-      CmdArgs.push_back("-dynamic-linker");
+-      CmdArgs.push_back(Args.MakeArgString(Loader));
+     }
+   }
+ 
+diff -ur cfe-7.0.1.src-orig/lib/Driver/ToolChains/Linux.cpp cfe-7.0.1.src/lib/Driver/ToolChains/Linux.cpp
+--- cfe-7.0.1.src-orig/lib/Driver/ToolChains/Linux.cpp	2018-12-29 19:48:00.045000000 -0800
++++ cfe-7.0.1.src/lib/Driver/ToolChains/Linux.cpp	2019-01-11 18:17:51.586000999 -0800
+@@ -213,18 +213,7 @@
+   llvm::Triple::ArchType Arch = Triple.getArch();
+   std::string SysRoot = computeSysRoot();
+ 
+-  // Cross-compiling binutils and GCC installations (vanilla and openSUSE at
+-  // least) put various tools in a triple-prefixed directory off of the parent
+-  // of the GCC installation. We use the GCC triple here to ensure that we end
+-  // up with tools that support the same amount of cross compiling as the
+-  // detected GCC installation. For example, if we find a GCC installation
+-  // targeting x86_64, but it is a bi-arch GCC installation, it can also be
+-  // used to target i386.
+-  // FIXME: This seems unlikely to be Linux-specific.
+-  ToolChain::path_list &PPaths = getProgramPaths();
+-  PPaths.push_back(Twine(GCCInstallation.getParentLibPath() + "/../" +
+-                         GCCInstallation.getTriple().str() + "/bin")
+-                       .str());
++  // Removed some code here that found programs like ld in "/..//bin"
+ 
+   Distro Distro(D.getVFS());
+ 
+@@ -238,15 +227,6 @@
+     ExtraOpts.push_back("relro");
+   }
+ 
+-  if (GCCInstallation.getParentLibPath().find("opt/rh/devtoolset") !=
+-      StringRef::npos)
+-    // With devtoolset on RHEL, we want to add a bin directory that is relative
+-    // to the detected gcc install, because if we are using devtoolset gcc then
+-    // we want to use other tools from devtoolset (e.g. ld) instead of the
+-    // standard system tools.
+-    PPaths.push_back(Twine(GCCInstallation.getParentLibPath() +
+-                     "/../bin").str());
+-
+   if (Arch == llvm::Triple::arm || Arch == llvm::Triple::thumb)
+     ExtraOpts.push_back("-X");
+ 

--- a/nix/nixcrpkgs/macos/clang_builder.sh
+++ b/nix/nixcrpkgs/macos/clang_builder.sh
@@ -22,9 +22,9 @@ cd build
 
 cmake ../llvm -GNinja -DDEFAULT_SYSROOT=$out -DCMAKE_INSTALL_PREFIX=$out $cmake_flags
 
-ninja
+# We use -j1 below so we can avoid running out of RAM on
+# systems with several cores and little RAM.
 
-ninja install
+ninja -j1
 
-# clang-tblgen is supposed to be an internal tool, but tapi needs it
-cp bin/clang-tblgen $out/bin
+ninja -j1 install

--- a/nix/nixcrpkgs/macos/clang_builder.sh
+++ b/nix/nixcrpkgs/macos/clang_builder.sh
@@ -22,9 +22,9 @@ cd build
 
 cmake ../llvm -GNinja -DDEFAULT_SYSROOT=$out -DCMAKE_INSTALL_PREFIX=$out $cmake_flags
 
-# We use -j1 below so we can avoid running out of RAM on
-# systems with several cores and little RAM.
+ninja
 
-ninja -j1
+ninja install
 
-ninja -j1 install
+# clang-tblgen is supposed to be an internal tool, but tapi needs it
+cp bin/clang-tblgen $out/bin

--- a/nix/nixcrpkgs/macos/compiler_rt.patch
+++ b/nix/nixcrpkgs/macos/compiler_rt.patch
@@ -1,0 +1,80 @@
+diff -ur compiler-rt-7.0.1.src-orig/cmake/base-config-ix.cmake compiler-rt-7.0.1.src/cmake/base-config-ix.cmake
+--- compiler-rt-7.0.1.src-orig/cmake/base-config-ix.cmake	2019-01-04 20:17:52.685000000 -0800
++++ compiler-rt-7.0.1.src/cmake/base-config-ix.cmake	2019-01-04 20:32:57.785000000 -0800
+@@ -89,16 +89,6 @@
+ endif()
+ 
+ if(APPLE)
+-  # On Darwin if /usr/include doesn't exist, the user probably has Xcode but not
+-  # the command line tools. If this is the case, we need to find the OS X
+-  # sysroot to pass to clang.
+-  if(NOT EXISTS /usr/include)
+-    execute_process(COMMAND xcodebuild -version -sdk macosx Path
+-       OUTPUT_VARIABLE OSX_SYSROOT
+-       ERROR_QUIET
+-       OUTPUT_STRIP_TRAILING_WHITESPACE)
+-    set(OSX_SYSROOT_FLAG "-isysroot${OSX_SYSROOT}")
+-  endif()
+ 
+   option(COMPILER_RT_ENABLE_IOS "Enable building for iOS" On)
+   option(COMPILER_RT_ENABLE_WATCHOS "Enable building for watchOS - Experimental" Off)
+diff -ur compiler-rt-7.0.1.src-orig/cmake/builtin-config-ix.cmake compiler-rt-7.0.1.src/cmake/builtin-config-ix.cmake
+--- compiler-rt-7.0.1.src-orig/cmake/builtin-config-ix.cmake	2019-01-04 20:17:52.685000000 -0800
++++ compiler-rt-7.0.1.src/cmake/builtin-config-ix.cmake	2019-01-04 21:35:18.881427998 -0800
+@@ -103,20 +103,6 @@
+     set(CAN_TARGET_${arch} 1)
+   endforeach()
+ 
+-  # Need to build a 10.4 compatible libclang_rt
+-  set(DARWIN_10.4_SYSROOT ${DARWIN_osx_SYSROOT})
+-  set(DARWIN_10.4_BUILTIN_MIN_VER 10.4)
+-  set(DARWIN_10.4_BUILTIN_MIN_VER_FLAG
+-      -mmacosx-version-min=${DARWIN_10.4_BUILTIN_MIN_VER})
+-  set(DARWIN_10.4_SKIP_CC_KEXT On)
+-  darwin_test_archs(10.4 DARWIN_10.4_ARCHS i386 x86_64)
+-  message(STATUS "OSX 10.4 supported builtin arches: ${DARWIN_10.4_ARCHS}")
+-  if(DARWIN_10.4_ARCHS)
+-    # don't include the Haswell slice in the 10.4 compatibility library
+-    list(REMOVE_ITEM DARWIN_10.4_ARCHS x86_64h)
+-    list(APPEND BUILTIN_SUPPORTED_OS 10.4)
+-  endif()
+-
+   foreach(platform ${DARWIN_EMBEDDED_PLATFORMS})
+     if(DARWIN_${platform}sim_SYSROOT)
+       set(DARWIN_${platform}sim_BUILTIN_MIN_VER
+diff -ur compiler-rt-7.0.1.src-orig/cmake/Modules/AddCompilerRT.cmake compiler-rt-7.0.1.src/cmake/Modules/AddCompilerRT.cmake
+--- compiler-rt-7.0.1.src-orig/cmake/Modules/AddCompilerRT.cmake	2019-01-04 20:17:52.685000000 -0800
++++ compiler-rt-7.0.1.src/cmake/Modules/AddCompilerRT.cmake	2019-01-06 21:53:52.696998594 -0800
+@@ -291,12 +291,6 @@
+         set_target_properties(${libname} PROPERTIES IMPORT_SUFFIX ".lib")
+       endif()
+       if(APPLE)
+-        # Ad-hoc sign the dylibs
+-        add_custom_command(TARGET ${libname}
+-          POST_BUILD  
+-          COMMAND codesign --sign - $<TARGET_FILE:${libname}>
+-          WORKING_DIRECTORY ${COMPILER_RT_LIBRARY_OUTPUT_DIR}
+-        )
+       endif()
+     endif()
+     install(TARGETS ${libname}
+diff -ur compiler-rt-7.0.1.src-orig/CMakeLists.txt compiler-rt-7.0.1.src/CMakeLists.txt
+--- compiler-rt-7.0.1.src-orig/CMakeLists.txt	2019-01-04 20:17:52.589000000 -0800
++++ compiler-rt-7.0.1.src/CMakeLists.txt	2019-01-04 20:57:57.233000000 -0800
+@@ -375,16 +375,6 @@
+ 
+ add_subdirectory(include)
+ 
+-foreach(path IN ITEMS ${LLVM_MAIN_SRC_DIR}/projects/libcxx
+-                      ${LLVM_MAIN_SRC_DIR}/runtimes/libcxx
+-                      ${LLVM_MAIN_SRC_DIR}/../libcxx
+-                      ${LLVM_EXTERNAL_LIBCXX_SOURCE_DIR})
+-  if(IS_DIRECTORY ${path})
+-    set(COMPILER_RT_LIBCXX_PATH ${path})
+-    break()
+-  endif()
+-endforeach()
+-
+ set(COMPILER_RT_LLD_PATH ${LLVM_MAIN_SRC_DIR}/tools/lld)
+ if(EXISTS ${COMPILER_RT_LLD_PATH}/ AND LLVM_TOOL_LLD_BUILD)
+   set(COMPILER_RT_HAS_LLD TRUE)

--- a/nix/nixcrpkgs/macos/compiler_rt_builder.sh
+++ b/nix/nixcrpkgs/macos/compiler_rt_builder.sh
@@ -1,0 +1,18 @@
+source $setup
+
+tar -xf $src
+mv compiler-rt-* src
+
+cd src
+for patch in $patches; do
+  echo applying patch $patch
+  patch -p1 -i $patch
+done
+cd ..
+
+mkdir build
+cd build
+cmake ../src -GNinja -DCMAKE_INSTALL_PREFIX=$out $cmake_flags
+
+ninja
+ninja install

--- a/nix/nixcrpkgs/macos/default.nix
+++ b/nix/nixcrpkgs/macos/default.nix
@@ -3,7 +3,7 @@
 # binutils.  So clang and binutils recipes could be shared by the
 # different platforms we targets.
 
-{ osx_sdk, native }:
+{ native }:
 let
   nixpkgs = native.nixpkgs;
 
@@ -12,38 +12,34 @@ let
   # was darwin15, changed to darwin so that lld guesses flavor=Darwin correctly
   darwin_name = "darwin15";
 
-  macos_version_min = "10.11";
+  # Qt 5.12 expects macOS 10.12 or later
+  # (see macx.conf and http://doc.qt.io/qt-5/macos.html).
+  macos_version_min = "10.12";
 
   host = "${arch}-apple-${darwin_name}";
 
-  os = "macos";
-
-  compiler = "clang";
-
-  exe_suffix = "";
-
   clang = native.make_derivation rec {
-    name = "clang";
+    name = "clang-${version}";
 
-    version = "5.0.0";
+    version = "7.0.1";
 
     src = nixpkgs.fetchurl {
-      url = "https://llvm.org/releases/${version}/cfe-${version}.src.tar.xz";
-      sha256 = "0w09s8fn3lkn6i04nj0cisgp821r815fk5b5fjn97xrd371277q1";
+      url = "http://releases.llvm.org/${version}/cfe-${version}.src.tar.xz";
+      sha256 = "067lwggnbg0w1dfrps790r5l6k8n5zwhlsw7zb6zvmfpwpfn4nx4";
     };
 
     llvm_src = nixpkgs.fetchurl {
-      url = "https://llvm.org/releases/${version}/llvm-${version}.src.tar.xz";
-      sha256 = "1nin64vz21hyng6jr19knxipvggaqlkl2l9jpd5czbc4c2pcnpg3";
+      url = "http://releases.llvm.org/${version}/llvm-${version}.src.tar.xz";
+      sha256 = "16s196wqzdw4pmri15hadzqgdi926zln3an2viwyq0kini6zr3d3";
     };
 
     # Note: We aren't actually using lld for anything yet.
     lld_src = nixpkgs.fetchurl {
       url = "http://releases.llvm.org/${version}/lld-${version}.src.tar.xz";
-      sha256 = "15rqsmfw0jlsri7hszbs8l0j7v1030cy9xvvdb245397llh7k6ir";
+      sha256 = "0ca0qygrk87lhjk6cpv1wbmdfnficqqjsda3k7b013idvnralsc8";
     };
 
-    patches = [ ./clang_megapatch.patch ];
+    patches = [ ./clang.patch ];
 
     builder = ./clang_builder.sh;
 
@@ -53,25 +49,28 @@ let
       "-DCMAKE_BUILD_TYPE=Release " +
       # "-DCMAKE_BUILD_TYPE=Debug " +
       "-DLLVM_TARGETS_TO_BUILD=X86\;ARM " +
-      "-DLLVM_ENABLE_RTTI=ON " +  # ld64 uses dynamic_cast, requiring rtti
       "-DLLVM_ENABLE_ASSERTIONS=OFF";
   };
 
-  # Note: There is an alternative version we could use, but it
-  # has a copy of LLVM in it: https://github.com/tpoechtrager/apple-libtapi
+  # Previously we used a port of Apple's TAPI library from here:
+  #   https://github.com/DavidEGrayson/tapi/archive/f98d0c3.tar.gz
+  # Another version of that libtrary is here:
+  #   https://github.com/tpoechtrager/apple-libtapi
+  # But those versions require LLVM and clang 5.0.0, so now we are using
+  # tinytapi instead.
   tapi = native.make_derivation rec {
-    name = "tapi";
-    version = "${version0}.${version1}.${version2}";
-    version0 = "2";
-    version1 = "0";
-    version2 = "0";
+    name = "tinytapi-${version}";
+
+    version = "1.0.0";
+
     src = nixpkgs.fetchurl {
-      url = "https://github.com/DavidEGrayson/tapi/archive/f98d0c3.tar.gz";
-      sha256 = "0jibz0fsyh47q8y3w6f0qspjh6fhs164rkhjg7x6k7qhlawcdy6g";
+      url = "https://github.com/DavidEGrayson/tinytapi/archive/${version}.tar.gz";
+      sha256 = "1hipsnpnlmrg63q7c7mx07dgc7sn86agf3jh1gys1rri0cdn1w1b";
     };
-    builder = ./tapi_builder.sh;
-    native_inputs = [ clang ];
-    inherit clang;
+
+    builder = ./tinytapi_builder.sh;
+    libyaml = nixpkgs.libyaml;
+    native_inputs = [ libyaml ];
   };
 
   cctools_commit = "c1cc758";
@@ -118,6 +117,17 @@ let
     inherit host ranlib;
   };
 
+  lipo = native.make_derivation rec {
+    name = "cctools-lipo";
+    apple_version = cctools_apple_version;
+    src = cctools_port_src;
+    builder = ./lipo_builder.sh;
+    patches = [
+      ./cctools-format.patch
+    ];
+    inherit host;
+  };
+
   strip = native.make_derivation rec {
     name = "cctools-strip";
     apple_version = cctools_apple_version;
@@ -129,19 +139,58 @@ let
     inherit host;
   };
 
-  # TODO: add instructions for building the SDK tarball, probably want a copy of
-  # the script from osxcross.
   sdk = native.make_derivation rec {
     name = "macos-sdk";
     builder = ./sdk_builder.sh;
-    src = osx_sdk;
+    src = ./MacOSX.sdk.tar.xz;
+    native_inputs = [ nixpkgs.ruby ];
+  } // {
+    version = builtins.readFile "${sdk}/version.txt";
+  };
+
+  # Note: compiler-rt actually builds itself for three different architectures:
+  # i386, x86_64, x86_64h.  It uses lipo to create fat archives that hold
+  # binaries for all the different architectures.  We only want x86_64 but it's
+  # not obvious how to achieve that.
+  compiler_rt = native.make_derivation rec {
+    name = "compiler-rt-${version}";
+
+    version = clang.version;
+
+    src = nixpkgs.fetchurl {
+      url = "http://releases.llvm.org/7.0.1/compiler-rt-${version}.src.tar.xz";
+      sha256 = "065ybd8fsc4h2hikbdyricj6pyv4r7r7kpcikhb2y5zf370xybkq";
+    };
+
+    builder = ./compiler_rt_builder.sh;
+
+    patches = [ ./compiler_rt.patch ];
+
+    native_inputs = [ clang ar ranlib lipo ld nixpkgs.python2 ];
+
+    _cflags = "-target ${host} --sysroot ${sdk} " +
+      "-I${sdk}/usr/include -mlinker-version=${ld.apple_version}";
+    CC = "clang ${_cflags}";
+    CXX = "clang++ ${_cflags} -stdlib=libc++ -cxx-isystem ${sdk}/usr/include/c++";
+
+    cmake_flags =
+      "-DCMAKE_BUILD_TYPE=Release " +
+      "-DCMAKE_SYSTEM_NAME=Darwin " +
+      "-DCMAKE_OSX_SYSROOT=${sdk} " +
+      "-DDARWIN_osx_SYSROOT=${sdk} " +
+      "-DCMAKE_LINKER=${ld}/bin/${host}-ld " +
+      "-DCMAKE_AR=${ar}/bin/${host}-ar " +
+      "-DCMAKE_RANLIB=${ranlib}/bin/${host}-ranlib " +
+      "-DCOMPILER_RT_BUILD_XRAY=OFF";
+
+    inherit host sdk;
   };
 
   toolchain = native.make_derivation rec {
     name = "macos-toolchain";
     builder = ./toolchain_builder.sh;
     src_file = ./wrapper.cpp;
-    inherit host clang ld ranlib ar strip sdk;
+    inherit host clang ld ranlib ar lipo strip;
 
     CXXFLAGS =
       "-std=c++11 " +
@@ -152,39 +201,38 @@ let
       "-DWRAPPER_HOST=\\\"${host}\\\" " +
       "-DWRAPPER_ARCH=\\\"${arch}\\\" " +
       "-DWRAPPER_SDK_PATH=\\\"${sdk}\\\" " +
+      "-DWRAPPER_COMPILER_RT_PATH=\\\"${compiler_rt}\\\" " +
       "-DWRAPPER_LINKER_VERSION=\\\"${ld.apple_version}\\\"";
   };
 
-  cmake_toolchain = import ../cmake_toolchain {
-    cmake_system_name = "Darwin";
-    inherit nixpkgs host;
-  };
-
-  crossenv = {
+  crossenv = rec {
     is_cross = true;
 
-    # Build tools available on the PATH for every derivation.
-    default_native_inputs = native.default_native_inputs
-      ++ [ clang toolchain native.wrappers ];
+    # Target info.
+    inherit host arch;
+    os = "macos";
+    inherit macos_version_min;
+    compiler = "clang";
+    exe_suffix = "";
+    cmake_system = "Darwin";
+    meson_system = "darwin";
+    meson_cpu_family = "x86_64";
+    meson_cpu = "x86_64";
 
-    # Target info environment variables.
-    inherit host arch os compiler exe_suffix macos_version_min;
-
-    # CMake toolchain file.
-    inherit cmake_toolchain;
-
-    # A wide variety of programs and build tools.
-    inherit nixpkgs;
-
-    # Some native build tools made by nixcrpkgs.
-    inherit native;
+    # Build tools.
+    inherit nixpkgs native;
+    wrappers = import ../wrappers crossenv;
 
     # License information that should be shipped with any software
     # compiled by this environment.
-    global_license_set = { };
+    global_license_set = { };  # TODO: compiler-rt
 
-    # Make it easy to build or refer to the build tools.
-    inherit clang tapi ld ranlib ar sdk toolchain strip;
+    # Handy shortcuts.
+    inherit clang compiler_rt tapi ld ranlib ar lipo sdk toolchain;
+
+    # Build tools available on the PATH for every derivation.
+    default_native_inputs = native.default_native_inputs
+      ++ [ clang toolchain wrappers ];
 
     make_derivation = import ../make_derivation.nix crossenv;
   };

--- a/nix/nixcrpkgs/macos/default.nix
+++ b/nix/nixcrpkgs/macos/default.nix
@@ -3,7 +3,7 @@
 # binutils.  So clang and binutils recipes could be shared by the
 # different platforms we targets.
 
-{ native }:
+{ osx_sdk, native }:
 let
   nixpkgs = native.nixpkgs;
 
@@ -12,34 +12,38 @@ let
   # was darwin15, changed to darwin so that lld guesses flavor=Darwin correctly
   darwin_name = "darwin15";
 
-  # Qt 5.12 expects macOS 10.12 or later
-  # (see macx.conf and http://doc.qt.io/qt-5/macos.html).
-  macos_version_min = "10.12";
+  macos_version_min = "10.11";
 
   host = "${arch}-apple-${darwin_name}";
 
-  clang = native.make_derivation rec {
-    name = "clang-${version}";
+  os = "macos";
 
-    version = "7.0.1";
+  compiler = "clang";
+
+  exe_suffix = "";
+
+  clang = native.make_derivation rec {
+    name = "clang";
+
+    version = "5.0.0";
 
     src = nixpkgs.fetchurl {
-      url = "http://releases.llvm.org/${version}/cfe-${version}.src.tar.xz";
-      sha256 = "067lwggnbg0w1dfrps790r5l6k8n5zwhlsw7zb6zvmfpwpfn4nx4";
+      url = "https://llvm.org/releases/${version}/cfe-${version}.src.tar.xz";
+      sha256 = "0w09s8fn3lkn6i04nj0cisgp821r815fk5b5fjn97xrd371277q1";
     };
 
     llvm_src = nixpkgs.fetchurl {
-      url = "http://releases.llvm.org/${version}/llvm-${version}.src.tar.xz";
-      sha256 = "16s196wqzdw4pmri15hadzqgdi926zln3an2viwyq0kini6zr3d3";
+      url = "https://llvm.org/releases/${version}/llvm-${version}.src.tar.xz";
+      sha256 = "1nin64vz21hyng6jr19knxipvggaqlkl2l9jpd5czbc4c2pcnpg3";
     };
 
     # Note: We aren't actually using lld for anything yet.
     lld_src = nixpkgs.fetchurl {
       url = "http://releases.llvm.org/${version}/lld-${version}.src.tar.xz";
-      sha256 = "0ca0qygrk87lhjk6cpv1wbmdfnficqqjsda3k7b013idvnralsc8";
+      sha256 = "15rqsmfw0jlsri7hszbs8l0j7v1030cy9xvvdb245397llh7k6ir";
     };
 
-    patches = [ ./clang.patch ];
+    patches = [ ./clang_megapatch.patch ];
 
     builder = ./clang_builder.sh;
 
@@ -49,28 +53,25 @@ let
       "-DCMAKE_BUILD_TYPE=Release " +
       # "-DCMAKE_BUILD_TYPE=Debug " +
       "-DLLVM_TARGETS_TO_BUILD=X86\;ARM " +
+      "-DLLVM_ENABLE_RTTI=ON " +  # ld64 uses dynamic_cast, requiring rtti
       "-DLLVM_ENABLE_ASSERTIONS=OFF";
   };
 
-  # Previously we used a port of Apple's TAPI library from here:
-  #   https://github.com/DavidEGrayson/tapi/archive/f98d0c3.tar.gz
-  # Another version of that libtrary is here:
-  #   https://github.com/tpoechtrager/apple-libtapi
-  # But those versions require LLVM and clang 5.0.0, so now we are using
-  # tinytapi instead.
+  # Note: There is an alternative version we could use, but it
+  # has a copy of LLVM in it: https://github.com/tpoechtrager/apple-libtapi
   tapi = native.make_derivation rec {
-    name = "tinytapi-${version}";
-
-    version = "1.0.0";
-
+    name = "tapi";
+    version = "${version0}.${version1}.${version2}";
+    version0 = "2";
+    version1 = "0";
+    version2 = "0";
     src = nixpkgs.fetchurl {
-      url = "https://github.com/DavidEGrayson/tinytapi/archive/${version}.tar.gz";
-      sha256 = "1hipsnpnlmrg63q7c7mx07dgc7sn86agf3jh1gys1rri0cdn1w1b";
+      url = "https://github.com/DavidEGrayson/tapi/archive/f98d0c3.tar.gz";
+      sha256 = "0jibz0fsyh47q8y3w6f0qspjh6fhs164rkhjg7x6k7qhlawcdy6g";
     };
-
-    builder = ./tinytapi_builder.sh;
-    libyaml = nixpkgs.libyaml;
-    native_inputs = [ libyaml ];
+    builder = ./tapi_builder.sh;
+    native_inputs = [ clang ];
+    inherit clang;
   };
 
   cctools_commit = "c1cc758";
@@ -117,17 +118,6 @@ let
     inherit host ranlib;
   };
 
-  lipo = native.make_derivation rec {
-    name = "cctools-lipo";
-    apple_version = cctools_apple_version;
-    src = cctools_port_src;
-    builder = ./lipo_builder.sh;
-    patches = [
-      ./cctools-format.patch
-    ];
-    inherit host;
-  };
-
   strip = native.make_derivation rec {
     name = "cctools-strip";
     apple_version = cctools_apple_version;
@@ -139,58 +129,19 @@ let
     inherit host;
   };
 
+  # TODO: add instructions for building the SDK tarball, probably want a copy of
+  # the script from osxcross.
   sdk = native.make_derivation rec {
     name = "macos-sdk";
     builder = ./sdk_builder.sh;
-    src = ./MacOSX.sdk.tar.xz;
-    native_inputs = [ nixpkgs.ruby ];
-  } // {
-    version = builtins.readFile "${sdk}/version.txt";
-  };
-
-  # Note: compiler-rt actually builds itself for three different architectures:
-  # i386, x86_64, x86_64h.  It uses lipo to create fat archives that hold
-  # binaries for all the different architectures.  We only want x86_64 but it's
-  # not obvious how to achieve that.
-  compiler_rt = native.make_derivation rec {
-    name = "compiler-rt-${version}";
-
-    version = clang.version;
-
-    src = nixpkgs.fetchurl {
-      url = "http://releases.llvm.org/7.0.1/compiler-rt-${version}.src.tar.xz";
-      sha256 = "065ybd8fsc4h2hikbdyricj6pyv4r7r7kpcikhb2y5zf370xybkq";
-    };
-
-    builder = ./compiler_rt_builder.sh;
-
-    patches = [ ./compiler_rt.patch ];
-
-    native_inputs = [ clang ar ranlib lipo ld nixpkgs.python2 ];
-
-    _cflags = "-target ${host} --sysroot ${sdk} " +
-      "-I${sdk}/usr/include -mlinker-version=${ld.apple_version}";
-    CC = "clang ${_cflags}";
-    CXX = "clang++ ${_cflags} -stdlib=libc++ -cxx-isystem ${sdk}/usr/include/c++";
-
-    cmake_flags =
-      "-DCMAKE_BUILD_TYPE=Release " +
-      "-DCMAKE_SYSTEM_NAME=Darwin " +
-      "-DCMAKE_OSX_SYSROOT=${sdk} " +
-      "-DDARWIN_osx_SYSROOT=${sdk} " +
-      "-DCMAKE_LINKER=${ld}/bin/${host}-ld " +
-      "-DCMAKE_AR=${ar}/bin/${host}-ar " +
-      "-DCMAKE_RANLIB=${ranlib}/bin/${host}-ranlib " +
-      "-DCOMPILER_RT_BUILD_XRAY=OFF";
-
-    inherit host sdk;
+    src = osx_sdk;
   };
 
   toolchain = native.make_derivation rec {
     name = "macos-toolchain";
     builder = ./toolchain_builder.sh;
     src_file = ./wrapper.cpp;
-    inherit host clang ld ranlib ar lipo strip;
+    inherit host clang ld ranlib ar strip sdk;
 
     CXXFLAGS =
       "-std=c++11 " +
@@ -201,38 +152,39 @@ let
       "-DWRAPPER_HOST=\\\"${host}\\\" " +
       "-DWRAPPER_ARCH=\\\"${arch}\\\" " +
       "-DWRAPPER_SDK_PATH=\\\"${sdk}\\\" " +
-      "-DWRAPPER_COMPILER_RT_PATH=\\\"${compiler_rt}\\\" " +
       "-DWRAPPER_LINKER_VERSION=\\\"${ld.apple_version}\\\"";
   };
 
-  crossenv = rec {
+  cmake_toolchain = import ../cmake_toolchain {
+    cmake_system_name = "Darwin";
+    inherit nixpkgs host;
+  };
+
+  crossenv = {
     is_cross = true;
-
-    # Target info.
-    inherit host arch;
-    os = "macos";
-    inherit macos_version_min;
-    compiler = "clang";
-    exe_suffix = "";
-    cmake_system = "Darwin";
-    meson_system = "darwin";
-    meson_cpu_family = "x86_64";
-    meson_cpu = "x86_64";
-
-    # Build tools.
-    inherit nixpkgs native;
-    wrappers = import ../wrappers crossenv;
-
-    # License information that should be shipped with any software
-    # compiled by this environment.
-    global_license_set = { };  # TODO: compiler-rt
-
-    # Handy shortcuts.
-    inherit clang compiler_rt tapi ld ranlib ar lipo sdk toolchain;
 
     # Build tools available on the PATH for every derivation.
     default_native_inputs = native.default_native_inputs
-      ++ [ clang toolchain wrappers ];
+      ++ [ clang toolchain native.wrappers ];
+
+    # Target info environment variables.
+    inherit host arch os compiler exe_suffix macos_version_min;
+
+    # CMake toolchain file.
+    inherit cmake_toolchain;
+
+    # A wide variety of programs and build tools.
+    inherit nixpkgs;
+
+    # Some native build tools made by nixcrpkgs.
+    inherit native;
+
+    # License information that should be shipped with any software
+    # compiled by this environment.
+    global_license_set = { };
+
+    # Make it easy to build or refer to the build tools.
+    inherit clang tapi ld ranlib ar sdk toolchain strip;
 
     make_derivation = import ../make_derivation.nix crossenv;
   };

--- a/nix/nixcrpkgs/macos/lipo_builder.sh
+++ b/nix/nixcrpkgs/macos/lipo_builder.sh
@@ -1,0 +1,43 @@
+source $setup
+
+tar -xf $src
+mv cctools-port-* cctools-port
+
+cd cctools-port
+
+for patch in $patches; do
+  echo applying patch $patch
+  patch -p1 -i $patch
+done
+
+# Similar to but not the same as the other _structs.h.
+rm cctools/include/foreign/mach/i386/_structs.h
+
+# Causes a troublesome undefined reference.
+rm cctools/libstuff/vm_flush_cache.c
+
+cd ..
+
+mv cctools-port/cctools/misc/lipo.c .
+mv cctools-port/cctools/include .
+mv cctools-port/cctools/libstuff .
+rm -r cctools-port
+
+mkdir build
+cd build
+
+CFLAGS="-Wno-deprecated -Wno-deprecated-declarations -Wno-unused-result -Werror -Wfatal-errors -O2 -g -I../include -I../include/foreign -DPROGRAM_PREFIX=\\\"$host-\\\" -D__LITTLE_ENDIAN__ -D__private_extern__= -D__DARWIN_UNIX03 -DPACKAGE_NAME=\\\"cctools\\\" -DPACKAGE_VERSION=\\\"$apple_version\\\" -DEMULATED_HOST_CPU_TYPE=16777223 -DEMULATED_HOST_CPU_SUBTYPE=3"
+
+CXXFLAGS="-std=gnu++11 $CFLAGS"
+
+LDFLAGS="-ldl -lpthread"
+
+for f in ../lipo.c ../libstuff/*.c; do
+  echo "compiling $f"
+  eval "gcc -c $CFLAGS $f -o $(basename $f).o"
+done
+
+gcc *.o $LDFLAGS -o lipo
+
+mkdir -p $out/bin
+cp lipo $out/bin/

--- a/nix/nixcrpkgs/macos/sdk_builder.sh
+++ b/nix/nixcrpkgs/macos/sdk_builder.sh
@@ -2,3 +2,11 @@ source $setup
 
 tar -xf $src
 mv MacOSX*.sdk $out
+
+cd $out
+ruby -rjson \
+  -e "print JSON.load(File.read('SDKSettings.json')).fetch('Version')" \
+  > version.txt
+
+# Make sure the STL headers are in the expected place.
+ls usr/include/c++/iterator > /dev/null

--- a/nix/nixcrpkgs/macos/sdk_builder.sh
+++ b/nix/nixcrpkgs/macos/sdk_builder.sh
@@ -2,11 +2,3 @@ source $setup
 
 tar -xf $src
 mv MacOSX*.sdk $out
-
-cd $out
-ruby -rjson \
-  -e "print JSON.load(File.read('SDKSettings.json')).fetch('Version')" \
-  > version.txt
-
-# Make sure the STL headers are in the expected place.
-ls usr/include/c++/iterator > /dev/null

--- a/nix/nixcrpkgs/macos/tinytapi_builder.sh
+++ b/nix/nixcrpkgs/macos/tinytapi_builder.sh
@@ -1,0 +1,31 @@
+source $setup
+
+tar -xf $src
+mv tinytapi-* tinytapi
+
+mkdir build
+cd build
+
+CFLAGS="-g -O2 -std=c++14 -Wall -Wextra"
+CFLAGS="$CFLAGS -I../tinytapi/include"
+g++ -c $CFLAGS ../tinytapi/src/tapi.cpp $(pkg-config --cflags yaml-0.1) -o tapi.o
+ar cr libtapi.a tapi.o
+
+mkdir -p $out/lib/pkgconfig
+
+cp libtapi.a $out/lib
+cp -r ../tinytapi/include $out/include
+
+cat > $out/lib/pkgconfig/libtapi.pc <<EOF
+prefix=$out
+libdir=\${prefix}/lib
+includedir=\${prefix}/include
+
+Name: libtapi
+Version: 2.0.0
+Libs: -L\${libdir} -ltapi
+Cflags: -I\${includedir}
+Requires: yaml-0.1
+EOF
+
+ln -s $libyaml/lib/pkgconfig/yaml-0.1.pc $out/lib/pkgconfig/

--- a/nix/nixcrpkgs/macos/toolchain_builder.sh
+++ b/nix/nixcrpkgs/macos/toolchain_builder.sh
@@ -4,15 +4,17 @@ mkdir -p $out/bin
 
 cd $out/bin
 
-CXXFLAGS="$CXXFLAGS -DWRAPPER_PATH=\\\"$out/bin:$ld/bin:$clang/bin\\\""
+CXXFLAGS="$CXXFLAGS -DWRAPPER_PATH=\\\"$out/bin:$clang/bin\\\""
 
 eval "g++ $CXXFLAGS $src_file -o $host-wrapper"
 
 ln -s $clang/bin/llvm-dsymutil dsymutil
 ln -s $ar/bin/$host-ar
+ln -s $lipo/bin/lipo
 ln -s $ranlib/bin/$host-ranlib
 ln -s $ranlib/bin/$host-libtool
 ln -s $strip/bin/$host-strip
+ln -s $ld/bin/$host-ld
 
 ln -s $host-wrapper $host-cc
 ln -s $host-wrapper $host-c++

--- a/nix/nixcrpkgs/macos/toolchain_builder.sh
+++ b/nix/nixcrpkgs/macos/toolchain_builder.sh
@@ -4,17 +4,15 @@ mkdir -p $out/bin
 
 cd $out/bin
 
-CXXFLAGS="$CXXFLAGS -DWRAPPER_PATH=\\\"$out/bin:$clang/bin\\\""
+CXXFLAGS="$CXXFLAGS -DWRAPPER_PATH=\\\"$out/bin:$ld/bin:$clang/bin\\\""
 
 eval "g++ $CXXFLAGS $src_file -o $host-wrapper"
 
 ln -s $clang/bin/llvm-dsymutil dsymutil
 ln -s $ar/bin/$host-ar
-ln -s $lipo/bin/lipo
 ln -s $ranlib/bin/$host-ranlib
 ln -s $ranlib/bin/$host-libtool
 ln -s $strip/bin/$host-strip
-ln -s $ld/bin/$host-ld
 
 ln -s $host-wrapper $host-cc
 ln -s $host-wrapper $host-c++

--- a/nix/nixcrpkgs/macos/wrapper.cpp
+++ b/nix/nixcrpkgs/macos/wrapper.cpp
@@ -48,7 +48,7 @@ int compiler_main(int argc, char ** argv,
   args.push_back("--sysroot");
   args.push_back(WRAPPER_SDK_PATH);
 
-  // Causes clang to pass -demangle,  -lto_library, -no_deduplicate, and other
+  // Causes clang to pass -demangle, -no_deduplicate, and other
   // options that could be useful.  Version 274.2 is the version number used here:
   // https://github.com/tpoechtrager/osxcross/blob/474f359/build.sh#L140
   if (WRAPPER_LINKER_VERSION[0])
@@ -60,7 +60,7 @@ int compiler_main(int argc, char ** argv,
   {
     args.push_back("-stdlib=libc++");
     args.push_back("-cxx-isystem");
-    args.push_back(WRAPPER_SDK_PATH "/usr/include/c++/v1");
+    args.push_back(WRAPPER_SDK_PATH "/usr/include/c++");
   }
 
   for (int i = 1; i < argc; ++i)
@@ -120,6 +120,13 @@ int main(int argc, char ** argv)
   if (result)
   {
     std::cerr << "wrapper failed to set PATH" << std::endl;
+    return 1;
+  }
+
+  result = setenv("COMPILER_RT_PATH", WRAPPER_COMPILER_RT_PATH, 1);
+  if (result)
+  {
+    std::cerr << "wrapper failed to set COMPILER_RT_PATH" << std::endl;
     return 1;
   }
 

--- a/nix/nixcrpkgs/macos/wrapper.cpp
+++ b/nix/nixcrpkgs/macos/wrapper.cpp
@@ -48,7 +48,7 @@ int compiler_main(int argc, char ** argv,
   args.push_back("--sysroot");
   args.push_back(WRAPPER_SDK_PATH);
 
-  // Causes clang to pass -demangle, -no_deduplicate, and other
+  // Causes clang to pass -demangle,  -lto_library, -no_deduplicate, and other
   // options that could be useful.  Version 274.2 is the version number used here:
   // https://github.com/tpoechtrager/osxcross/blob/474f359/build.sh#L140
   if (WRAPPER_LINKER_VERSION[0])
@@ -60,7 +60,7 @@ int compiler_main(int argc, char ** argv,
   {
     args.push_back("-stdlib=libc++");
     args.push_back("-cxx-isystem");
-    args.push_back(WRAPPER_SDK_PATH "/usr/include/c++");
+    args.push_back(WRAPPER_SDK_PATH "/usr/include/c++/v1");
   }
 
   for (int i = 1; i < argc; ++i)
@@ -120,13 +120,6 @@ int main(int argc, char ** argv)
   if (result)
   {
     std::cerr << "wrapper failed to set PATH" << std::endl;
-    return 1;
-  }
-
-  result = setenv("COMPILER_RT_PATH", WRAPPER_COMPILER_RT_PATH, 1);
-  if (result)
-  {
-    std::cerr << "wrapper failed to set COMPILER_RT_PATH" << std::endl;
     return 1;
   }
 

--- a/nix/nixcrpkgs/make_derivation.nix
+++ b/nix/nixcrpkgs/make_derivation.nix
@@ -51,7 +51,6 @@ let
     NIXCRPKGS = true;
 
     inherit (env) host arch os exe_suffix;
-    inherit (env) cmake_toolchain;
 
     PKG_CONFIG_CROSS_PATH = path_join (
       (if attrs ? PKG_CONFIG_CROSS_PATH then [attrs.PKG_CONFIG_CROSS_PATH] else []) ++

--- a/nix/nixcrpkgs/manage
+++ b/nix/nixcrpkgs/manage
@@ -1,0 +1,566 @@
+#!/usr/bin/env ruby
+
+# A script that helps us check that the derivations we care about can all be
+# built.
+
+require 'open3'
+require 'pathname'
+require 'set'
+require_relative 'support/graph'
+require_relative 'support/expand_brackets'
+
+# Backport Hash#transform_values if we aren't using a new-enough Ruby.
+class Hash
+  def transform_values(&block)
+    r = self.class.new
+    each do |key, value|
+      r[key] = yield value
+    end
+    r
+  end
+end unless Hash.instance_methods.include?(:transform_values)
+
+# Back port Array#sum if we aren't using a new-enough Ruby.
+class Array
+  def sum
+    inject(0, :+)
+  end
+end
+
+class AnticipatedError < RuntimeError
+end
+
+# Don't automatically change directory because maybe people want to test one
+# nixcrpkgs repository using the test script from another one.  But do give an
+# early, friendly warning if they are running in the wrong directory.
+def check_directory!
+  return if File.directory?('pretend_stdenv')
+  $stderr.puts "You should run this script from the nixcrpkgs directory."
+  dir = Pathname(__FILE__).parent
+  $stderr.puts "Try running these commands:\n  cd #{dir}\n  ./manage"
+  exit 1
+end
+
+def substitute_definitions(defs, str)
+  str.gsub(/\$([\w-]+)/) do |x|
+    defs.fetch($1)
+  end
+end
+
+def parse_derivation_list(filename)
+  defs = {}
+  all_paths = Set.new
+  all_attrs = {}
+  File.foreach(filename).with_index do |line, line_index|
+    begin
+      line.strip!
+
+      # Handle empty lines and comments.
+      next if line.empty? || line.start_with?('#')
+
+      # Handle variable definitions (e.g. "define windows = win32,win64").
+      if line.start_with?('define')
+        md = line.match(/^define\s+([\w-]+)\s*=\s*(.*)$/)
+        if !md
+          raise AnticipatedError, "Invalid definition syntax."
+        end
+        name, value = md[1], md[2]
+        defs[name] = value
+        next
+      end
+
+      # Expand variable definitions (e.g. $windows expands to "win32,win64").
+      line = substitute_definitions(defs, line)
+
+      # Figure out which parts of the line are attribute paths with brackets and
+      # which are attributes.
+      items = line.split(' ')
+      attr_defs, path_items = items.partition { |p| p.include?('=') }
+
+      # Expand any brackets in the attribute paths to get the complete list of
+      # paths specified on this line.
+      paths = path_items.flat_map { |p| expand_brackets(p) }.map(&:to_sym)
+
+      # Process attribute definitions on the line, like "priority=1".
+      attrs = {}
+      attr_defs.each do |attr_def|
+        md = attr_def.match(/^(\w+)=(\d+)$/)
+        if !md
+          raise AnticipatedError, "Invalid attribute definition: #{attr_def.inspect}."
+        end
+        name, value = md[1], md[2]
+        case name
+        when 'priority', 'slow'
+          attrs[name.to_sym] = value.to_i
+        else
+          raise AnticipatedError, "Unrecognized attribute: #{name.inspect}."
+        end
+      end
+
+      # Record the paths for this line and the attributes for those paths,
+      # overriding previous attributes values if necessary.
+      all_paths += paths
+      if !attrs.empty?
+        paths.each do |path|
+          (all_attrs[path] ||= {}).merge!(attrs)
+        end
+      end
+    rescue AnticipatedError => e
+      raise AnticipatedError, "#{filename}:#{line_index + 1}: error: #{e}"
+    end
+  end
+
+  if all_paths.empty?
+    raise AnticipatedError, "#{filename} specifies no paths"
+  end
+
+  all_paths.each do |path|
+    if !path.match(/^[\w.-]+$/)
+      raise "Invalid characters in path name: #{path}"
+    end
+  end
+
+  { defs: defs, paths: all_paths.to_a, attrs: all_attrs }
+end
+
+# Make a hash holding the priority of each Nix attribute path we want to build.
+# This routine determines the default priority.
+def make_path_priority_map(settings)
+  attrs = settings.fetch(:attrs)
+  m = {}
+  settings.fetch(:paths).each do |path|
+    m[path] = attrs.fetch(path, {}).fetch(:priority, 0)
+  end
+  m
+end
+
+# Make a hash holding the relative build time of each Nix attribute path we want
+# to build.  This routine detrmines the default time, and what "slow" means.
+def make_path_time_map(settings)
+  attrs = settings.fetch(:attrs)
+  m = {}
+  settings.fetch(:paths).each do |path|
+    m[path] = attrs.fetch(path, {})[:slow] ? 100 : 1
+  end
+  m
+end
+
+def instantiate_drvs(paths)
+  cmd = 'nix-instantiate ' + paths.map { |p| "-A #{p}" }.join(' ')
+  stdout_str, stderr_str, status = Open3.capture3(cmd)
+  if !status.success?
+    $stderr.puts stderr_str
+    raise AnticipatedError, "Failed to instantiate derivations."
+  end
+  paths.zip(stdout_str.split.map(&:to_sym)).to_h
+end
+
+# We want there to be a one-to-one mapping between paths in the derivations.txt
+# list and derivations, so we can make a graph of dependencies of the
+# derivations and each derivation in the graph will have a unique path in the
+# derivations.txt list.
+def check_paths_are_unique!(path_drv_map)
+  set = Set.new
+  path_drv_map.each do |key, drv|
+    if set.include?(drv)
+      raise AnticipatedError, "The derivation #{key} is the same as " \
+        "other derivations in the list.  Maybe use the 'omni' namespace."
+    end
+    set << drv
+  end
+end
+
+# Makes a new map that has the same keys as map1, and the values
+# have all been mapped by map2.
+#
+# Requires map2 to have a key for every value in map1.
+def map_compose(map1, map2)
+  map1.transform_values &map2.method(:fetch)
+end
+
+# Like map_compose, but excludes keys from map1 where the corresponding map1
+# value is not a key of map2.
+def map_join(map1, map2)
+  r = {}
+  map1.each do |key, value|
+    if map2.key?(value)
+      r[key] = map2.fetch(value)
+    end
+  end
+  r
+end
+
+def nix_db
+  return $db if $db
+  require 'sqlite3'  # gem install sqlite3
+  $db = SQLite3::Database.new '/nix/var/nix/db/db.sqlite', readonly: true
+end
+
+# Given an array of derivations (paths to .drv files in /nix), this function
+# queries the Nix database and returns hash table mapping derivations to
+# a boolean that is true if they have already been built.
+def get_build_status(drvs)
+  drv_list_str = drvs.map { |d| "\"#{d}\"" }.join(", ")
+  query = <<END
+select d.path, v.id
+from ValidPaths d
+left join DerivationOutputs o on d.id == o.drv
+left join ValidPaths v on o.path == v.path
+where d.path in (#{drv_list_str});
+END
+  r = {}
+  nix_db.execute(query) do |drv, output_id|
+    drv = drv.to_sym
+    output_built = !output_id.nil?
+    r[drv] = r.fetch(drv, true) && output_built
+  end
+  r
+end
+
+# Given an array of derivations (paths to .drv files in /nix), returns
+# a hash mapping each derivation to a map that maps derivation output
+# names to valid paths in the Nix store.
+def get_valid_results(drvs)
+  drv_list_str = drvs.map { |d| "\"#{d}\"" }.join(", ")
+  query = <<END
+select d.path, o.id, o.path
+from ValidPaths d
+join DerivationOutputs o on d.id == o.drv
+join ValidPaths v on o.path == v.path
+where d.path in (#{drv_list_str});
+END
+  r = {}
+  nix_db.execute(query) do |drv, output_id, output_path|
+    drv = drv.to_sym
+    r[drv] ||= {}
+    r[drv][output_id.to_sym] = output_path
+  end
+  r
+end
+
+# Returns a map that maps every derivation path to a list of derivation paths
+# that it refers to, for all derivations in the Nix store.
+def get_drv_graph
+  map = {}
+  query = <<END
+select r1.path, r2.path
+from Refs r
+join ValidPaths r1 on r1.id == referrer
+join ValidPaths r2 on r2.id == reference
+where r1.path like '%.drv' and r2.path like '%.drv';
+END
+  nix_db.execute(query) do |drv1, drv2|
+    drv1 = drv1.to_sym
+    drv2 = drv2.to_sym
+    (map[drv1] ||= []) << drv2
+    map[drv2] ||= []
+  end
+  map
+end
+
+def graph_restrict_nodes(graph, allowed_nodes)
+  graph = restricted_transitive_closure(graph, Set.new(allowed_nodes))
+  transitive_reduction(graph)
+end
+
+def graph_unmap(graph, map)
+  rmap = {}
+  map.each do |k, v|
+    raise "Mapping is not one-to-one: multiple items map to #{v}" if rmap.key?(v)
+    rmap[v] = k
+  end
+  gu = {}
+  graph.each do |parent, children|
+    gu[rmap.fetch(parent)] = children.map do |child|
+      rmap.fetch(child)
+    end
+  end
+  gu
+end
+
+def print_status(built_map)
+  built_count = built_map.count { |drv, built| built }
+  puts "Derivations built: #{built_count} out of #{built_map.size}"
+end
+
+def output_graphviz(path_state)
+  path_graph = path_state.fetch(:graph)
+  path_priority_map = path_state.fetch(:priority_map)
+  path_time_map = path_state.fetch(:time_map)
+  path_built_map = path_state.fetch(:built_map)
+
+  # Breaks a path name into two parts: subgraph name, component name.
+  # For example, for :"linux32.qt.examples", returns ["linux32", "qt.examples"].
+  decompose = lambda do |path|
+    r = path.to_s.split('.', 2)
+    r.size == 2 ? r : [nil, path.to_s]
+  end
+
+  # Make one subgraph for each system (e.g. 'linux32', 'win32').  Decide which
+  # paths to show in the graph, excluding omni.* paths because the make the
+  # graphs really messy.
+  subgraph_names = Set.new
+  visible_paths = []
+  path_graph.each_key do |path|
+    subgraph, component = decompose.(path)
+    next if subgraph == 'omni'
+    subgraph_names << subgraph
+    visible_paths << path
+  end
+
+  File.open('paths.gv', 'w') do |f|
+    f.puts "digraph {"
+    f.puts "node ["
+    f.puts "colorscheme=\"accent3\""
+    f.puts "]"
+    subgraph_names.sort.each do |subgraph_name|
+      # Output the subgraphs and the nodes in them.
+      f.puts "subgraph \"cluster_#{subgraph_name}\" {"
+      f.puts "label=\"#{subgraph_name}\";"
+      path_graph.each do |path, deps|
+        subgraph, component = decompose.(path)
+        next if subgraph != subgraph_name
+        more_attrs = ''
+
+        # Show nodes that are built with a green background.
+        if path_built_map.fetch(path)
+          more_attrs << " style=filled fillcolor=\"1\""
+        end
+
+        # Draw high-priority nodes with a thick pen.
+        if path_priority_map.fetch(path) > 0
+          more_attrs << " penwidth=3"
+        end
+
+        # Draw slow nodes as a double octagon.
+        if path_time_map.fetch(path) > 10
+          more_attrs << " shape=doubleoctagon"
+        end
+        f.puts "\"#{path}\" [label=\"#{component}\"#{more_attrs}]"
+      end
+      f.puts "}"
+    end
+
+    # Output dependencies between nodes.
+    visible_paths.each do |path|
+      path_graph.fetch(path).each do |dep|
+        next if decompose.(dep).first == 'omni'
+        f.puts "\"#{path}\" -> \"#{dep}\""
+      end
+    end
+    f.puts "}"
+  end
+end
+
+def make_build_plan(path_state)
+  path_graph = path_state.fetch(:graph)
+  path_priority_map = path_state.fetch(:priority_map)
+  path_time_map = path_state.fetch(:time_map)
+  path_built_map = path_state.fetch(:built_map)
+
+  # It's handy to be able to get all the dependencies of a node in one step, and
+  # we will use that frequently to calculate how expensive it is to build a
+  # node and to make the toplogical sort.
+  path_graph = transitive_closure(path_graph).freeze
+
+  # The paths we need to build.  In the future we could filter this by priority.
+  required_paths = Set.new(path_graph.keys).freeze
+
+  # built_paths: The set of paths that are already built.  We will mutate this
+  # as we simulate our build plan.
+  built_paths = Set.new
+  path_built_map.each do |path, built|
+    built_paths << path if built
+  end
+
+  # List of paths to build.  Each path should only be built once all the paths
+  # it depends on are built.  I know nix-build can take care of that for us, but
+  # it's nice to see the precise order of what is going to be built so we can
+  # tell when slow things will get built.
+  build_plan = []
+
+  # Computes the time to build a path, taking into account what has already been
+  # built.
+  calculate_time = lambda do |path|
+    deps = path_graph.fetch(path) + [path]
+    deps.reject! &built_paths.method(:include?)
+    deps.map(&path_time_map.method(:fetch)).sum
+  end
+
+  # Adds plans to build this path and all of its unbuilt depedencies.
+  add_to_build_plan = lambda do |path|
+    deps = path_graph.fetch(path) + [path]
+
+    # Remove dependencies that are already built.
+    deps.reject! &built_paths.method(:include?)
+
+    # Topological sort
+    deps.sort! do |p1, p2|
+      case
+      when path_graph.fetch(p1).include?(p2) then 1
+      when path_graph.fetch(p2).include?(p1) then -1
+      else 0
+      end
+    end
+
+    deps.each do |path|
+      build_plan << path
+      built_paths << path
+    end
+  end
+
+  while true
+    unbuilt_required_paths = required_paths - built_paths
+    break if unbuilt_required_paths.empty?
+
+    # Find the maximum priority of the unbuilt required paths.
+    max_priority = nil
+    unbuilt_required_paths.each do |path|
+      priority = path_priority_map.fetch(path)
+      if !max_priority || priority > max_priority
+        max_priority = priority
+      end
+    end
+
+    top_priority_paths = unbuilt_required_paths.select do |path|
+      path_priority_map.fetch(path) == max_priority
+    end
+
+    target = top_priority_paths.min_by(&calculate_time)
+
+    add_to_build_plan.(target)
+  end
+
+  build_plan
+end
+
+def build_paths(path_graph, path_built_map, build_plan, keep_going: true)
+  path_built_map = path_built_map.dup
+  path_graph = transitive_closure(path_graph)
+  build_plan.each do |path|
+    if !path_graph.fetch(path).all?(&path_built_map.method(:fetch))
+      # One of the dependencies of this path has not been built, presumably
+      # because there was an error.
+      puts "# skipping #{path}"
+      next
+    end
+
+    print "nix-build -A #{path}"
+    system("nix-build -A #{path} > /dev/null 2> /dev/null")
+
+    if $?.success?
+      path_built_map[path] = true
+      puts
+    else
+      puts " # failed"
+      return false if !keep_going
+    end
+  end
+  true
+end
+
+def update_gcroots
+  system("nix-instantiate -A gcroots --add-root #{Dir.pwd}/gcroots.drv --indirect > /dev/null")
+  if !$?.success?
+    raise AnticipatedError, "Failed to update GC roots."
+  end
+end
+
+def parse_args(argv)
+  action = case argv.first
+           when 'gcroots' then :gcroots
+           when 'graph' then :graph
+           when 'build' then :build
+           when 'plan' then :plan
+           when 'status' then :status
+           when 'help', nil then :help
+           else raise AnticipatedError, "Invalid action: #{argv.first.inspect}"
+           end
+
+  { action: action }
+end
+
+begin
+  check_directory!
+  args = parse_args(ARGV)
+  action = args.fetch(:action)
+
+  if action == :help
+    puts <<END
+Usage: support/manage action
+
+gcroots:
+  Update gcroots.drv and add it as a garbage collector root so that you can
+  run 'nix-collect-garbage -d' without deleting useful items, assuming
+  the keep-outputs option is enabled in nix.conf.
+graph:
+  Generate a Graphviz graph of derivations of dependencies to paths.gv.
+plan:
+  Show the derivation build plan as a series of 'nix-build' commands.
+build:
+  Try to build all derivations we care about.  Keeps going if a build fails.
+status:
+  Print out statistics about the derivations we care about and how many are
+  already built.
+help:
+  Print this message.
+
+The derivations we care about are defined in support/derivations.txt.
+END
+  end
+
+  if action == :gcroots
+    update_gcroots
+  end
+
+  if [:graph, :build, :plan, :status].include?(action)
+    settings = parse_derivation_list('support/derivations.txt')
+
+    path_drv_map = instantiate_drvs(settings.fetch(:paths))
+    check_paths_are_unique!(path_drv_map)
+
+    drvs = path_drv_map.values.uniq
+    drv_built_map = get_build_status(drvs)
+  end
+
+  if [:graph, :build, :plan].include?(action)
+    global_drv_graph = get_drv_graph
+    drv_graph = graph_restrict_nodes(global_drv_graph, drvs)
+    path_state = {
+      graph: graph_unmap(drv_graph, path_drv_map).freeze,
+      priority_map: make_path_priority_map(settings).freeze,
+      time_map: make_path_time_map(settings).freeze,
+      built_map: map_compose(path_drv_map, drv_built_map).freeze,
+    }.freeze
+  end
+
+  if action == :graph
+    output_graphviz(path_state)
+  end
+
+  if [:build, :plan].include?(action)
+    build_plan = make_build_plan(path_state)
+  end
+
+  if action == :plan
+    build_plan.each do |path|
+      puts "nix-build -A #{path}"
+    end
+  end
+
+  if action == :build
+    success = build_paths(path_state[:graph], path_state[:built_map], build_plan)
+    exit(1) if !success
+  end
+
+  if action == :build
+    drv_valid_results_map = get_valid_results(drvs)
+    path_valid_results_map = map_join(path_drv_map, drv_valid_results_map).freeze
+  end
+
+  if action == :status
+    print_status(drv_built_map)
+  end
+rescue AnticipatedError => e
+  $stderr.puts e
+end

--- a/nix/nixcrpkgs/mingw-w64/binutils/default.nix
+++ b/nix/nixcrpkgs/mingw-w64/binutils/default.nix
@@ -3,18 +3,16 @@
 native.make_derivation rec {
   name = "binutils-${version}-${host}";
 
-  version = "2.27";
+  version = "2.31";
 
   src = native.nixpkgs.fetchurl {
-    url = "mirror://gnu/binutils/binutils-${version}.tar.bz2";
-    sha256 = "125clslv17xh1sab74343fg6v31msavpmaa1c1394zsqa773g5rn";
+    url = "mirror://gnu/binutils/binutils-${version}.tar.xz";
+    sha256 = "1gqn887nqfyd5l6gfv08m1pg4wg5fm2iys7hpz6lj87hgvgkc413";
   };
 
   patches = [
     ./deterministic.patch
   ];
-
-  build_inputs = [ native.nixpkgs.bison native.nixpkgs.zlib ];
 
   configure_flags =
     "--target=${host} " +

--- a/nix/nixcrpkgs/mingw-w64/default.nix
+++ b/nix/nixcrpkgs/mingw-w64/default.nix
@@ -9,14 +9,13 @@ let
 
   mingw-w64_info = rec {
     name = "mingw-w64-${version}";
-    version = "2017-08-03";
+    version = "2018-10-18";
     src = nixpkgs.fetchgit {
       url = "git://git.code.sf.net/p/mingw-w64/mingw-w64";
-      rev = "6de0055f99ed447ec63c1a650a3830f266a808bd";
-      sha256 = "1830rcd0vsbvpr5m1lrabcqh12qrw1flq333b8xrs5b3n542xy2i";
+      rev = "c69c7a706d767c5ca3c7d1c70887fcd8e1f940b3";
+      sha256 = "028g8wpy56m3nlna6dnzsz66355kn6gqmwmkm9raas9s1ayzv5il";
     };
     patches = [
-      ./usb.patch
       ./guid-selectany.patch
     ];
     configure_flags = "--enable-secure-api --enable-idl";
@@ -63,42 +62,38 @@ let
 
   global_license_set = { _global = license; };
 
-  cmake_toolchain = import ../cmake_toolchain {
-    cmake_system_name = "Windows";
-    inherit nixpkgs host;
-  };
-
-  os = "windows";
-
-  compiler = "gcc";
-
-  exe_suffix = ".exe";
-
-  crossenv = {
+  crossenv = rec {
     is_cross = true;
 
-    default_native_inputs = native.default_native_inputs
-      ++ [ gcc binutils native.pkgconf native.wrappers ];
+    # Target info.
+    inherit host arch;
+    os = "windows";
+    compiler = "gcc";
+    exe_suffix = ".exe";
+    cmake_system = "Windows";
+    meson_system = "windows";
+    meson_cpu_family =
+      if arch == "i686" then "x86"
+      else if arch == "x86_64" then "x86_64"
+      else throw "not sure what meson_cpu_family code to use";
+    meson_cpu = arch;
 
-    # Target info variables.
-    inherit host arch os compiler exe_suffix;
+    # Build tools.
+    inherit nixpkgs native;
+    wrappers = import ../wrappers crossenv;
 
-    # CMake toolchain file.
-    inherit cmake_toolchain;
-
-    # A wide variety of programs and build tools.
-    inherit nixpkgs;
-
-    # Some native build tools made by nixcrpkgs.
-    inherit native;
-
-    # License information that should be shipped with any software compiled by
-    # this environment.
+    # License information that should be shipped with any software
+    # compiled by this environment.
     inherit global_license_set;
 
-    # Make it easy to build or refer to the build tools.
-    inherit gcc binutils mingw-w64_full mingw-w64_info mingw-w64_headers gcc_stage_1;
+    # Handy shortcuts.
+    inherit gcc binutils;
+    inherit mingw-w64_full mingw-w64_info mingw-w64_headers gcc_stage_1;
     mingw-w64 = mingw-w64_full;
+
+    # Build tools available on the PATH for every derivation.
+    default_native_inputs = native.default_native_inputs
+      ++ [ gcc binutils wrappers ];
 
     make_derivation = import ../make_derivation.nix crossenv;
   };

--- a/nix/nixcrpkgs/mingw-w64/gcc/builder.sh
+++ b/nix/nixcrpkgs/mingw-w64/gcc/builder.sh
@@ -1,8 +1,9 @@
 source $setup
 
 tar -xf $src
+mv gcc-* src
 
-cd gcc-$version
+cd src
 for patch in $patches; do
   echo applying patch $patch
   patch -p1 -i $patch
@@ -53,7 +54,7 @@ cd ../..
 mkdir build
 cd build
 
-../gcc-$version/configure --prefix=$out $configure_flags
+../src/configure --prefix=$out $configure_flags
 
 make $make_flags
 

--- a/nix/nixcrpkgs/mingw-w64/gcc/default.nix
+++ b/nix/nixcrpkgs/mingw-w64/gcc/default.nix
@@ -2,7 +2,7 @@
 
 let
   nixpkgs = native.nixpkgs;
-  isl = nixpkgs.isl_0_14;
+  isl = nixpkgs.isl;
   inherit (nixpkgs) stdenv lib fetchurl;
   inherit (nixpkgs) gettext gmp libmpc libelf mpfr texinfo which zlib;
 
@@ -15,33 +15,43 @@ native.make_derivation rec {
 
   target = "${arch}-w64-mingw32";
 
-  version = "6.3.0";
+  version = "8.2.0";
 
   src = fetchurl {
-    url = "mirror://gnu/gcc/gcc-${version}/gcc-${version}.tar.bz2";
-    sha256 = "17xjz30jb65hcf714vn9gcxvrrji8j20xm7n33qg1ywhyzryfsph";
+    url = "mirror://gnu/gcc/gcc-${version}/gcc-${version}.tar.xz";
+    sha256 = "10007smilswiiv2ymazr3b6x2i933c0ycxrr529zh4r6p823qv0r";
   };
 
   builder = ./builder.sh;
 
   patches = [
-    # TODO: combine three of these patches into one called search-dirs.patch
+    # Make it so GCC does not force us to have a "mingw" symlink.
     ./mingw-search-paths.patch
-    ./use-source-date-epoch.patch
-    ./libstdc++-target.patch
-    ./no-sys-dirs.patch
+
+    # Make --with-sysroot and --with-native-system-header-dir work
+    # as described in the GCC documentation.
     ./cppdefault.patch
 
-    # Fix a compiler error in GCC's ubsan.c: ISO C++ forbids comparison
-    # between pointer and integer.
-    ./ubsan.patch
+    # Remove hardcoded absolute paths.
+    ./no-sys-dirs.patch
+
+    # Fix a bug in GCC that causes an internal compiler error when
+    # compiling Qt's qrandom.cpp:
+    # https://gcc.gnu.org/bugzilla/show_bug.cgi?id=58372#c14
+    # Patch is from comment #42 by Uros Bizjak.
+    # https://gcc.gnu.org/viewcvs/gcc/branches/gcc-8-branch/gcc/cfgexpand.c?view=patch&r1=264557&r2=266014&pathrev=266014
+    ./stack-alignment-58372.patch
+
+    # This patch is from nixpkgs.
+    ./libstdc++-target.patch
+
+    # Fix compilation errors about missing ISL function declarations.
+    # https://gcc.gnu.org/git/?p=gcc.git;a=patch;h=05103aed1d34b5ca07c9a70c95a7cb1d47e22c47
+    ./isl-headers.patch
   ];
 
-  # TODO: can probably remove libelf here, and might as well remove
-  # the libraries that are given to GCC as configure flags
-  # TODO: just let GCC use its own gettext (intl)
   native_inputs = [
-    binutils gettext libelf texinfo which zlib
+    binutils texinfo gettext which
   ];
 
   configure_flags =
@@ -82,8 +92,7 @@ native.make_derivation rec {
     "--disable-multilib " +
     "--disable-libssp " +
     "--disable-win32-registry " +
-    "--disable-bootstrap";  # TODO: not needed, --disable-bootstrap
-                            # only applies to native builds
+    "--disable-bootstrap";
 
   make_flags =
     if stage == 1 then

--- a/nix/nixcrpkgs/mingw-w64/gcc/isl-headers.patch
+++ b/nix/nixcrpkgs/mingw-w64/gcc/isl-headers.patch
@@ -1,0 +1,11 @@
+--- a/gcc/graphite.h
++++ b/gcc/graphite.h
+@@ -26,6 +26,8 @@
+ #include <isl/options.h>
+ #include <isl/ctx.h>
+ #include <isl/val.h>
++#include <isl/id.h>
++#include <isl/space.h>
+ #include <isl/set.h>
+ #include <isl/union_set.h>
+ #include <isl/map.h>

--- a/nix/nixcrpkgs/mingw-w64/gcc/libstdc++-target.patch
+++ b/nix/nixcrpkgs/mingw-w64/gcc/libstdc++-target.patch
@@ -1,7 +1,4 @@
 Patch to make the target libraries 'configure' scripts find the proper CPP.
-I noticed that building the mingw32 cross compiler.
-Looking at the build script for mingw in archlinux, I think that only nixos
-needs this patch. I don't know why.
 diff --git a/Makefile.in b/Makefile.in
 index 93f66b6..d691917 100644
 --- a/Makefile.in

--- a/nix/nixcrpkgs/mingw-w64/gcc/mingw-search-paths.patch
+++ b/nix/nixcrpkgs/mingw-w64/gcc/mingw-search-paths.patch
@@ -1,5 +1,3 @@
-Make it so GCC does not force us to have a "mingw" symlink.
-
 --- gcc-6.3.0-orig/gcc/config/i386/mingw32.h
 +++ gcc-6.3.0/gcc/config/i386/mingw32.h
 @@ -163,3 +163,3 @@

--- a/nix/nixcrpkgs/mingw-w64/gcc/no-sys-dirs.patch
+++ b/nix/nixcrpkgs/mingw-w64/gcc/no-sys-dirs.patch
@@ -1,4 +1,3 @@
-diff -ru -x '*~' gcc-4.8.3-orig/gcc/cppdefault.c gcc-4.8.3/gcc/cppdefault.c
 --- gcc-4.8.3-orig/gcc/cppdefault.c	2013-01-10 21:38:27.000000000 +0100
 +++ gcc-4.8.3/gcc/cppdefault.c	2014-08-18 16:20:32.893944536 +0200
 @@ -35,6 +35,8 @@

--- a/nix/nixcrpkgs/mingw-w64/gcc/stack-alignment-58372.patch
+++ b/nix/nixcrpkgs/mingw-w64/gcc/stack-alignment-58372.patch
@@ -1,0 +1,30 @@
+--- gcc-8/gcc/cfgexpand.c
++++ gcc-8/gcc/cfgexpand.c
+@@ -6548,6 +6548,14 @@
+   find_many_sub_basic_blocks (blocks);
+   purge_all_dead_edges ();
+ 
++  /* After initial rtl generation, call back to finish generating
++     exception support code.  We need to do this before cleaning up
++     the CFG as the code does not expect dead landing pads.  */
++  if (fun->eh->region_tree != NULL)
++    finish_eh_generation ();
++
++  /* Call expand_stack_alignment after finishing all
++     updates to crtl->preferred_stack_boundary.  */
+   expand_stack_alignment ();
+ 
+   /* Fixup REG_EQUIV notes in the prologue if there are tailcalls in this
+@@ -6555,12 +6563,6 @@
+   if (crtl->tail_call_emit)
+     fixup_tail_calls ();
+ 
+-  /* After initial rtl generation, call back to finish generating
+-     exception support code.  We need to do this before cleaning up
+-     the CFG as the code does not expect dead landing pads.  */
+-  if (fun->eh->region_tree != NULL)
+-    finish_eh_generation ();
+-
+   /* BB subdivision may have created basic blocks that are are only reachable
+      from unlikely bbs but not marked as such in the profile.  */
+   if (optimize)

--- a/nix/nixcrpkgs/native/default.nix
+++ b/nix/nixcrpkgs/native/default.nix
@@ -33,20 +33,12 @@ let
 
   pkgconf = import ./pkgconf { env = native_base; };
 
-  wrappers = import ./wrappers { env = native_base; };
-
-  gnu_config = nixpkgs.fetchgit {
-    url = "https://git.savannah.gnu.org/git/config.git";
-    rev = "81497f5aaf50a12a9fe0cba30ef18bda46b62959";
-    sha256 = "1fq0nki2118zwbc8rdkqx5i04lbfw7gqbsyf5bscg5im6sfphq1d";
-  };
-
   native = native_base // {
     default_native_inputs = native_base.default_native_inputs ++ [
       pkgconf
     ];
 
-    inherit pkgconf wrappers gnu_config;
+    inherit pkgconf;
 
     make_derivation = import ../make_derivation.nix native;
   };

--- a/nix/nixcrpkgs/native/pkgconf/builder.sh
+++ b/nix/nixcrpkgs/native/pkgconf/builder.sh
@@ -1,15 +1,20 @@
 source $setup
 
 tar -xf $src
+mv pkgconf-* pkgconf
+
+cd pkgconf
+for patch in $patches; do
+  echo applying patch $patch
+  patch -p1 -i $patch
+done
+./autogen.sh
+cd ..
 
 mkdir build
-
 cd build
 
-../pkgconf-$version/configure \
-  --prefix=$out \
-  --with-system-libdir=/no-system-libdir/ \
-  --with-system-includedir=/no-system-includedir/
+../pkgconf/configure --prefix=$out
 
 make
 
@@ -18,4 +23,4 @@ make install
 ln -s $out/bin/pkgconf $out/bin/pkg-config
 
 mkdir $out/license
-cp ../pkgconf-$version/COPYING $out/license/LICENSE
+cp ../pkgconf/COPYING $out/license/LICENSE

--- a/nix/nixcrpkgs/native/pkgconf/default.nix
+++ b/nix/nixcrpkgs/native/pkgconf/default.nix
@@ -1,14 +1,38 @@
+# We use pkgconf instead of pkg-config because pkg-config considers it to be
+# an error when there are two "Libs" fields in a .pc file.  Because we do
+# static linking, we often need to edit the pc files with sed to change
+# Libs.private into a second Libs field.
+
 { env }:
 
 env.make_derivation rec {
   name = "pkgconf-${version}";
 
-  version = "1.0.1";
+  version = "1.6.0";
 
   src = env.nixpkgs.fetchurl {
-    url = "https://github.com/pkgconf/pkgconf/releases/download/pkgconf-${version}/pkgconf-${version}.tar.gz";
-    sha256 = "1w9wb2z7zz6s4mifbllvhx0401bwsynhp02v312i6i9jn1m2zkj5";
+    url = "https://github.com/pkgconf/pkgconf/archive/pkgconf-${version}.tar.gz";
+    sha256 = "1j3700iyjvd4m4ahf827lzbzlji6q3higrnynqhdk2zklxq8shml";
   };
+
+  patches = [
+    # Fix a bug in pkgconf that causes it to ignore entries on its path
+    # that are symbolic links.
+    ./do-not-read-link.patch
+
+    # Fix a bug in pkgconf that causes it to silently skip .pc files
+    # missing the "Description" field.
+    ./do-not-require-description.patch
+  ];
+
+  native_inputs = [
+    env.nixpkgs.autoconf
+    env.nixpkgs.automake
+    env.nixpkgs.libtool
+    env.nixpkgs.m4
+  ];
+
+  ACLOCAL_PATH = "${env.nixpkgs.libtool}/share/aclocal";
 
   builder = ./builder.sh;
 }

--- a/nix/nixcrpkgs/native/pkgconf/do-not-read-link.patch
+++ b/nix/nixcrpkgs/native/pkgconf/do-not-read-link.patch
@@ -1,0 +1,21 @@
+--- a/libpkgconf/path.c
++++ b/libpkgconf/path.c
+@@ -90,18 +90,6 @@ pkgconf_path_add(const char *text, pkgconf_list_t *dirlist, bool filter)
+ 	{
+ 		if (lstat(path, &st) == -1)
+ 			return;
+-		if (S_ISLNK(st.st_mode))
+-		{
+-			char linkdest[PKGCONF_ITEM_SIZE];
+-			ssize_t len;
+-
+-			memset(linkdest, '\0', sizeof linkdest);
+-			len = readlink(path, linkdest, sizeof linkdest);
+-
+-			if (len != -1 && (size_t)len < sizeof(linkdest) &&
+-				stat(linkdest, &st) == -1)
+-				return;
+-		}
+ 		if (path_list_contains_entry(path, dirlist, &st))
+ 			return;
+ 	}

--- a/nix/nixcrpkgs/native/pkgconf/do-not-require-description.patch
+++ b/nix/nixcrpkgs/native/pkgconf/do-not-require-description.patch
@@ -1,0 +1,10 @@
+--- a/libpkgconf/pkg.c
++++ b/libpkgconf/pkg.c
+@@ -284,7 +284,6 @@ typedef struct {
+ 
+ static const pkgconf_pkg_validity_check_t pkgconf_pkg_validations[] = {
+ 	{"Name", offsetof(pkgconf_pkg_t, realname)},
+-	{"Description", offsetof(pkgconf_pkg_t, description)},
+ 	{"Version", offsetof(pkgconf_pkg_t, version)},
+ };
+ 

--- a/nix/nixcrpkgs/pkgs.nix
+++ b/nix/nixcrpkgs/pkgs.nix
@@ -20,18 +20,9 @@ rec {
     inherit crossenv;
   };
 
-  lmdb = import ./pkgs/lmdb {
-    inherit crossenv;
-  };
-
-  ncurses = import ./pkgs/ncurses {
-    inherit crossenv;
-  };
-
   pdcurses = import ./pkgs/pdcurses {
     inherit crossenv;
   };
-  pdcurses_examples = pdcurses.examples;
 
   readline = import ./pkgs/readline {
     inherit crossenv;
@@ -43,22 +34,6 @@ rec {
   };
 
   zlib = import ./pkgs/zlib {
-    inherit crossenv;
-  };
-
-  libgmp = import ./pkgs/libgmp {
-    inherit crossenv;
-  };
-
-  libsigsegv = import ./pkgs/libsigsegv {
-    inherit crossenv;
-  };
-
-  curl = import ./pkgs/curl {
-    inherit crossenv openssl zlib;
-  };
-
-  openssl = import ./pkgs/openssl {
     inherit crossenv;
   };
 
@@ -91,10 +66,6 @@ rec {
     inherit crossenv libusb;
   };
 
-  angle = import ./pkgs/angle {
-    inherit crossenv gdb;
-  };
-
   xcb-proto = import ./pkgs/xcb-proto {
     inherit crossenv;
   };
@@ -103,18 +74,17 @@ rec {
     inherit crossenv;
   };
 
-  xproto = import ./pkgs/xproto {
+  xorgproto = import ./pkgs/xorgproto {
     inherit crossenv xorg-macros;
   };
 
   libxau = import ./pkgs/libxau {
-    inherit crossenv xorg-macros xproto;
+    inherit crossenv xorg-macros xorgproto;
   };
 
   libxcb = import ./pkgs/libxcb {
     inherit crossenv xcb-proto libxau;
   };
-  libxcb_examples = libxcb.examples;
 
   xcb-util = import ./pkgs/xcb-util {
     inherit crossenv libxcb;
@@ -140,47 +110,32 @@ rec {
     inherit crossenv;
   };
 
-  xextproto = import ./pkgs/xextproto {
-    inherit crossenv;
-  };
-
-  inputproto = import ./pkgs/inputproto {
-    inherit crossenv;
-  };
-
-  kbproto = import ./pkgs/kbproto {
-    inherit crossenv;
-  };
-
-  fixesproto = import ./pkgs/fixesproto {
-    inherit crossenv xorg-macros xextproto;
-  };
-
   libx11 = import ./pkgs/libx11 {
-    inherit crossenv xorg-macros xproto libxcb xtrans;
-    inherit xextproto inputproto kbproto;
+    inherit crossenv xorg-macros xorgproto xtrans libxcb;
   };
 
   libxext = import ./pkgs/libxext {
-    inherit crossenv xproto xextproto libx11;
+    inherit crossenv xorgproto libx11;
   };
 
   libxfixes = import ./pkgs/libxfixes {
-    inherit crossenv xproto xextproto fixesproto libx11;
+    inherit crossenv xorgproto libx11;
   };
 
   libxi = import ./pkgs/libxi {
-    inherit crossenv xproto xextproto inputproto;
-    inherit libx11 libxext libxfixes;
+    inherit crossenv xorgproto libx11 libxext libxfixes;
+  };
+
+  libxkbcommon = import ./pkgs/libxkbcommon {
+     inherit crossenv libxcb;
   };
 
   libxall = import ./pkgs/libxall {
     inherit crossenv;
     libs = [
-      xcb-proto xorg-macros xproto libxau libxcb
+      xcb-proto xorg-macros xorgproto libxau libxcb
       xcb-util xcb-util-image xcb-util-keysyms xcb-util-renderutil xcb-util-wm
-      xtrans xextproto inputproto kbproto fixesproto
-      libx11 libxext libxfixes libxi
+      xtrans libx11 libxext libxfixes libxi libxkbcommon
     ];
   };
 
@@ -189,10 +144,6 @@ rec {
   };
 
   dejavu-fonts = import ./pkgs/dejavu-fonts {
-    inherit crossenv;
-  };
-
-  ion = import ./pkgs/ion {
     inherit crossenv;
   };
 

--- a/nix/nixcrpkgs/pkgs.nix
+++ b/nix/nixcrpkgs/pkgs.nix
@@ -20,6 +20,14 @@ rec {
     inherit crossenv;
   };
 
+  lmdb = import ./pkgs/lmdb {
+    inherit crossenv;
+  };
+
+  ncurses = import ./pkgs/ncurses {
+    inherit crossenv;
+  };
+
   pdcurses = import ./pkgs/pdcurses {
     inherit crossenv;
   };
@@ -34,6 +42,22 @@ rec {
   };
 
   zlib = import ./pkgs/zlib {
+    inherit crossenv;
+  };
+
+  libgmp = import ./pkgs/libgmp {
+    inherit crossenv;
+  };
+
+  libsigsegv = import ./pkgs/libsigsegv {
+    inherit crossenv;
+  };
+
+  curl = import ./pkgs/curl {
+    inherit crossenv openssl zlib;
+  };
+
+  openssl = import ./pkgs/openssl {
     inherit crossenv;
   };
 
@@ -64,6 +88,10 @@ rec {
 
   openocd = import ./pkgs/openocd {
     inherit crossenv libusb;
+  };
+
+  angle = import ./pkgs/angle {
+    inherit crossenv gdb;
   };
 
   xcb-proto = import ./pkgs/xcb-proto {
@@ -144,6 +172,10 @@ rec {
   };
 
   dejavu-fonts = import ./pkgs/dejavu-fonts {
+    inherit crossenv;
+  };
+
+  ion = import ./pkgs/ion {	
     inherit crossenv;
   };
 

--- a/nix/nixcrpkgs/pkgs/at-spi2-headers/builder.sh
+++ b/nix/nixcrpkgs/pkgs/at-spi2-headers/builder.sh
@@ -8,5 +8,6 @@ cat > $out/lib/pkgconfig/atspi-2.pc <<EOF
 prefix=$out
 includedir=\${prefix}/include
 Name: atspi
+Version: 2
 Cflags: -I\${includedir}
 EOF

--- a/nix/nixcrpkgs/pkgs/avrdude/builder.sh
+++ b/nix/nixcrpkgs/pkgs/avrdude/builder.sh
@@ -3,11 +3,15 @@ source $setup
 tar -xf $src
 mv avrdude-* avrdude
 
-ls -lad avrdude
 cd avrdude
 chmod -R u+w .
+for patch in $patches; do
+  echo applying patch $patch
+  patch -p1 -i $patch
+done
 cp $config_dot_sub config.sub
 cat $extra_conf >> avrdude.conf.in
+echo -n > windows/giveio.sys
 cd ..
 
 mkdir build
@@ -21,3 +25,6 @@ cd build
 make
 
 make install
+
+cd $out/bin
+rm -fv loaddrv* *.bat *.sys

--- a/nix/nixcrpkgs/pkgs/avrdude/default.nix
+++ b/nix/nixcrpkgs/pkgs/avrdude/default.nix
@@ -16,6 +16,8 @@ crossenv.make_derivation rec {
     sha256 = "15m1w1qad3dj7r8n5ng1qqcaiyx1gyd6hnc3p2apgjllccdp77qg";
   };
 
+  patches = [ ./faster.patch ];
+
   native_inputs = [
     crossenv.nixpkgs.yacc
     crossenv.nixpkgs.flex

--- a/nix/nixcrpkgs/pkgs/avrdude/faster.patch
+++ b/nix/nixcrpkgs/pkgs/avrdude/faster.patch
@@ -1,0 +1,73 @@
+diff -ur avrdude-6.3-orig/arduino.c avrdude-6.3/arduino.c
+--- avrdude-6.3-orig/arduino.c	2019-11-20 18:23:59.425987648 -0800
++++ avrdude-6.3/arduino.c	2019-11-20 18:52:03.653987648 -0800
+@@ -92,16 +92,11 @@
+   /* Clear DTR and RTS to unload the RESET capacitor 
+    * (for example in Arduino) */
+   serial_set_dtr_rts(&pgm->fd, 0);
+-  usleep(250*1000);
++  usleep(20*1000);
+   /* Set DTR and RTS back to high */
+   serial_set_dtr_rts(&pgm->fd, 1);
+   usleep(50*1000);
+ 
+-  /*
+-   * drain any extraneous input
+-   */
+-  stk500_drain(pgm, 0);
+-
+   if (stk500_getsync(pgm) < 0)
+     return -1;
+ 
+diff -ur avrdude-6.3-orig/ser_posix.c avrdude-6.3/ser_posix.c
+--- avrdude-6.3-orig/ser_posix.c	2019-11-20 18:23:59.425987648 -0800
++++ avrdude-6.3/ser_posix.c	2019-11-20 18:30:02.425987648 -0800
+@@ -436,7 +436,7 @@
+   unsigned char buf;
+ 
+   timeout.tv_sec = 0;
+-  timeout.tv_usec = 250000;
++  timeout.tv_usec = 50000;
+ 
+   if (display) {
+     avrdude_message(MSG_INFO, "drain>");
+diff -ur avrdude-6.3-orig/ser_win32.c avrdude-6.3/ser_win32.c
+--- avrdude-6.3-orig/ser_win32.c	2019-11-20 18:23:59.425987648 -0800
++++ avrdude-6.3/ser_win32.c	2019-11-20 18:53:58.433987648 -0800
+@@ -644,7 +644,7 @@
+ 		return -1;
+ 	}
+ 
+-	serial_w32SetTimeOut(hComPort,250);
++	serial_w32SetTimeOut(hComPort,50);
+   
+ 	if (display) {
+ 		avrdude_message(MSG_INFO, "drain>");
+diff -ur avrdude-6.3-orig/stk500.c avrdude-6.3/stk500.c
+--- avrdude-6.3-orig/stk500.c	2019-11-20 18:23:59.425987648 -0800
++++ avrdude-6.3/stk500.c	2019-11-20 18:41:22.241987648 -0800
+@@ -43,7 +43,7 @@
+ #include "stk500_private.h"
+ 
+ #define STK500_XTAL 7372800U
+-#define MAX_SYNC_ATTEMPTS 10
++#define MAX_SYNC_ATTEMPTS 1
+ 
+ struct pdata
+ {
+@@ -94,14 +94,7 @@
+    * get in sync */
+   buf[0] = Cmnd_STK_GET_SYNC;
+   buf[1] = Sync_CRC_EOP;
+-  
+-  /*
+-   * First send and drain a few times to get rid of line noise 
+-   */
+-   
+-  stk500_send(pgm, buf, 2);
+-  stk500_drain(pgm, 0);
+-  stk500_send(pgm, buf, 2);
++
+   stk500_drain(pgm, 0);
+ 
+   for (attempt = 0; attempt < MAX_SYNC_ATTEMPTS; attempt++) {

--- a/nix/nixcrpkgs/pkgs/dejavu-fonts/default.nix
+++ b/nix/nixcrpkgs/pkgs/dejavu-fonts/default.nix
@@ -6,7 +6,7 @@ let
   name = "dejavu-fonts-${version}";
 
   src = crossenv.nixpkgs.fetchurl {
-    # Sourceforge went down.  The original URL was:
+    # The original URL was:
     # http://sourceforge.net/projects/dejavu/files/dejavu/${version}/dejavu-fonts-ttf-${version}.tar.bz2";
     url = "https://files.tmphax.com/repo1/dejavu-fonts-ttf-${version}.tar.bz2";
     sha256 = "1mqpds24wfs5cmfhj57fsfs07mji2z8812i5c4pi5pbi738s977s";

--- a/nix/nixcrpkgs/pkgs/devcon/default.nix
+++ b/nix/nixcrpkgs/pkgs/devcon/default.nix
@@ -5,13 +5,13 @@ if crossenv.os != "windows" then "windows only" else
 crossenv.make_derivation rec {
   name = "devcon-${version}";
 
-  version = "2017-05-01";
+  version = "2019-01-24";
 
   src = crossenv.nixpkgs.fetchFromGitHub {
     owner = "Microsoft";
     repo = "Windows-driver-samples";
-    rev = "4c5c5e0297c7a61e151f92af702cdac650a14489";
-    sha256 = "1drq26bnad98xqn805qx0b6g4y65lmrdj7v40b3jhhzdsp8993pf";
+    rev = "39d39e7485faddf601d51c897863ff2f876e391e";
+    sha256 = "0nyw3wzlh68zxpb0ydzkgpf5c83scapfp6zsc5gahxlcgrhy3xwj";
   };
 
   patches = [];

--- a/nix/nixcrpkgs/pkgs/expat/builder.sh
+++ b/nix/nixcrpkgs/pkgs/expat/builder.sh
@@ -1,8 +1,9 @@
 source $setup
 
 tar -xf $src
+mv expat-* expat
 
-cd expat-$version
+cd expat
 for patch in $patches; do
   echo applying patch $patch
   patch -p1 -i $patch
@@ -12,7 +13,7 @@ cd ..
 mkdir build
 cd build
 
-../expat-$version/configure \
+../expat/configure \
   --prefix=$out --host=$host \
   --enable-static --disable-shared
 
@@ -20,7 +21,5 @@ make
 
 make install
 
-mv $out/bin/xmlwf $out/bin/xmlwf.exe
-
 mkdir $out/license
-cp ../expat-$version/COPYING $out/license/LICENSE
+cp ../expat/COPYING $out/license/LICENSE

--- a/nix/nixcrpkgs/pkgs/expat/default.nix
+++ b/nix/nixcrpkgs/pkgs/expat/default.nix
@@ -3,18 +3,16 @@
 crossenv.make_derivation rec {
   name = "expat-${version}";
 
-  version = "2.2.0";
+  version = "2.2.6";
 
   src = crossenv.nixpkgs.fetchurl {
-    # Sourceforge went down.  The original URL we used was:
+    # The original URL was:
     # mirror://sourceforge/expat/expat-${version}.tar.bz2
     url = "https://files.tmphax.com/repo1/expat-${version}.tar.bz2";
-    sha256 = "1zq4lnwjlw8s9mmachwfvfjf2x3lk24jm41746ykhdcvs7r0zrfr";
+    sha256 = "1wl1x93b5w457ddsdgj0lh7yjq4q6l7wfbgwhagkc8fm2qkkrd0p";
   };
 
-  patches = [
-    ./cve-2016-0718.patch
-  ];
+  patches = [];
 
   builder = ./builder.sh;
 }

--- a/nix/nixcrpkgs/pkgs/gdb/default.nix
+++ b/nix/nixcrpkgs/pkgs/gdb/default.nix
@@ -11,18 +11,14 @@
 crossenv.make_derivation rec {
   name = "gdb-${version}";
 
-  version = "7.12.1";
+  version = "8.2.1";
 
   src = crossenv.nixpkgs.fetchurl {
     url = "https://ftp.gnu.org/gnu/gdb/gdb-${version}.tar.xz";
-    sha256 = "11ii260h1sd7v0bs3cz6d5l8gqxxgldry0md60ncjgixjw5nh1s6";
+    sha256 = "00i27xqawjv282a07i73lp1l02n0a3ywzhykma75qg500wll6sha";
   };
 
-  patches = [
-    # Make GCC better at finding source files.
-    # https://sourceware.org/ml/gdb-patches/2017-02/msg00693.html
-    ./substitute-path-all-filenames.patch
-  ];
+  patches = [];
 
   native_inputs = [
     crossenv.nixpkgs.texinfo

--- a/nix/nixcrpkgs/pkgs/libudev/builder.sh
+++ b/nix/nixcrpkgs/pkgs/libudev/builder.sh
@@ -10,26 +10,23 @@ for patch in $patches; do
 done
 cd ..
 
-$host-g++ -x c++ -c $size_flags - -o test.o <<EOF
-#include <type_traits>
+$host-g++ -x c -c $size_flags - -o test.o <<EOF
+#include <assert.h>
 #include <sys/types.h>
 #include <sys/resource.h>
-static_assert(sizeof(pid_t) == SIZEOF_PID_T);
-static_assert(sizeof(uid_t) == SIZEOF_UID_T);
-static_assert(sizeof(gid_t) == SIZEOF_GID_T);
-static_assert(sizeof(time_t) == SIZEOF_TIME_T);
-static_assert(sizeof(rlim_t) == SIZEOF_RLIM_T);
-static_assert(sizeof(dev_t) == SIZEOF_DEV_T);
-static_assert(sizeof(ino_t) == SIZEOF_INO_T);
+static_assert(sizeof(pid_t) == SIZEOF_PID_T, "pid_t");
+static_assert(sizeof(uid_t) == SIZEOF_UID_T, "uid_t");
+static_assert(sizeof(gid_t) == SIZEOF_GID_T, "gid_t");
+static_assert(sizeof(time_t) == SIZEOF_TIME_T, "time_t");
+static_assert(sizeof(rlim_t) == SIZEOF_RLIM_T, "rlim_t");
+static_assert(sizeof(dev_t) == SIZEOF_DEV_T, "dev_t");
+static_assert(sizeof(ino_t) == SIZEOF_INO_T, "ino_t");
 EOF
 
 rm test.o
 
 mkdir build
 cd build
-
-# -DHAVE_SECURE_GETENV: We don't have secure_getenv but we want to avoid a header error,
-# and hopefully secure_getenv isn't actually needed by libudev.
 
 $host-gcc -c -Werror -I$fill $fill/*.c
 $host-gcc -c $CFLAGS \

--- a/nix/nixcrpkgs/pkgs/libudev/default.nix
+++ b/nix/nixcrpkgs/pkgs/libudev/default.nix
@@ -34,7 +34,10 @@ let
         "-DSIZEOF_INO_T=8 " +
         "-DSIZEOF_DEV_T=8";
 
-    CFLAGS = "-Werror -DHAVE_DECL_SETNS -D_GNU_SOURCE ${size_flags}";
+    CFLAGS = "-Werror -D_GNU_SOURCE " +
+      "-DHAVE_DECL_SETNS " +
+      "-DHAVE_DECL_MEMFD_CREATE " +
+      size_flags;
   };
 
   license = crossenv.native.make_derivation {

--- a/nix/nixcrpkgs/pkgs/libudev/megapatch.patch
+++ b/nix/nixcrpkgs/pkgs/libudev/megapatch.patch
@@ -1,6 +1,17 @@
+diff -ur systemd-234-orig/src/basic/fileio.c systemd-234/src/basic/fileio.c
+--- systemd-234-orig/src/basic/fileio.c	2018-11-04 21:39:40.344176543 -0800
++++ systemd-234/src/basic/fileio.c	2018-11-04 21:51:43.707619173 -0800
+@@ -24,6 +24,7 @@
+ #include <stdint.h>
+ #include <stdlib.h>
+ #include <string.h>
++#include <sys/mman.h>
+ #include <sys/stat.h>
+ #include <sys/types.h>
+ #include <unistd.h>
 diff -ur systemd-234-orig/src/basic/glob-util.c systemd-234/src/basic/glob-util.c
---- systemd-234-orig/src/basic/glob-util.c	2017-07-17 19:46:03.031674662 -0700
-+++ systemd-234/src/basic/glob-util.c	2017-07-22 20:11:56.931514364 -0700
+--- systemd-234-orig/src/basic/glob-util.c	2018-11-04 21:39:40.344176543 -0800
++++ systemd-234/src/basic/glob-util.c	2018-11-04 21:40:15.341171709 -0800
 @@ -31,22 +31,8 @@
  int safe_glob(const char *path, int flags, glob_t *pglob) {
          int k;
@@ -43,9 +54,10 @@ diff -ur systemd-234-orig/src/basic/glob-util.c systemd-234/src/basic/glob-util.
          if (k < 0)
                  return k;
  
+Only in systemd-234/src/basic: glob-util.c.rej
 diff -ur systemd-234-orig/src/basic/missing.h systemd-234/src/basic/missing.h
---- systemd-234-orig/src/basic/missing.h	2017-07-17 19:46:03.031674662 -0700
-+++ systemd-234/src/basic/missing.h	2017-07-21 08:02:12.349505168 -0700
+--- systemd-234-orig/src/basic/missing.h	2018-11-04 21:39:40.344176543 -0800
++++ systemd-234/src/basic/missing.h	2018-11-04 21:40:15.341171709 -0800
 @@ -40,6 +40,22 @@
  #include <uchar.h>
  #include <unistd.h>
@@ -79,8 +91,8 @@ diff -ur systemd-234-orig/src/basic/missing.h systemd-234/src/basic/missing.h
  #endif
  
 diff -ur systemd-234-orig/src/basic/mkdir.c systemd-234/src/basic/mkdir.c
---- systemd-234-orig/src/basic/mkdir.c	2017-07-17 19:46:03.031674662 -0700
-+++ systemd-234/src/basic/mkdir.c	2017-07-22 21:09:51.065274838 -0700
+--- systemd-234-orig/src/basic/mkdir.c	2018-11-04 21:39:40.347509908 -0800
++++ systemd-234/src/basic/mkdir.c	2018-11-04 21:40:15.341171709 -0800
 @@ -28,6 +28,7 @@
  #include "path-util.h"
  #include "stat-util.h"
@@ -90,8 +102,8 @@ diff -ur systemd-234-orig/src/basic/mkdir.c systemd-234/src/basic/mkdir.c
  int mkdir_safe_internal(const char *path, mode_t mode, uid_t uid, gid_t gid, mkdir_func_t _mkdir) {
          struct stat st;
 diff -ur systemd-234-orig/src/basic/parse-util.c systemd-234/src/basic/parse-util.c
---- systemd-234-orig/src/basic/parse-util.c	2017-07-17 19:46:03.031674662 -0700
-+++ systemd-234/src/basic/parse-util.c	2017-07-21 07:59:05.337491775 -0700
+--- systemd-234-orig/src/basic/parse-util.c	2018-11-04 21:39:40.347509908 -0800
++++ systemd-234/src/basic/parse-util.c	2018-11-04 21:40:15.344505074 -0800
 @@ -30,6 +30,7 @@
  #include "parse-util.h"
  #include "process-util.h"

--- a/nix/nixcrpkgs/pkgs/libusb/builder.sh
+++ b/nix/nixcrpkgs/pkgs/libusb/builder.sh
@@ -25,3 +25,6 @@ if [ -n "$libudev" ]; then
   ln -s $libudev/lib/pkgconfig/*.pc $out/lib/pkgconfig/
   echo "Requires: libudev" >> $out/lib/pkgconfig/libusb-1.0.pc
 fi
+
+# Make static linking work
+sed -i 's/Libs.private/Libs/' $out/lib/pkgconfig/*.pc

--- a/nix/nixcrpkgs/pkgs/libx11/builder.sh
+++ b/nix/nixcrpkgs/pkgs/libx11/builder.sh
@@ -15,10 +15,10 @@ make install
 
 # Make static linking work.
 sed -i 's/Requires.private/Requires/' $out/lib/pkgconfig/*.pc
+sed -i 's/Libs.private/Libs/' $out/lib/pkgconfig/*.pc
 
 ln -s x11-xcb.pc $out/lib/pkgconfig/X11-xcb.pc
 ln -s x11.pc $out/lib/pkgconfig/X11.pc
 
-ln -sf $xproto/lib/pkgconfig/*.pc $out/lib/pkgconfig/
-ln -sf $kbproto/lib/pkgconfig/*.pc $out/lib/pkgconfig/
+ln -sf $xorgproto/lib/pkgconfig/*.pc $out/lib/pkgconfig/
 ln -sf $libxcb/lib/pkgconfig/*.pc $out/lib/pkgconfig/

--- a/nix/nixcrpkgs/pkgs/libx11/default.nix
+++ b/nix/nixcrpkgs/pkgs/libx11/default.nix
@@ -1,14 +1,13 @@
-{ crossenv, xorg-macros, xproto, libxcb, xtrans,
-  xextproto, inputproto, kbproto }:
+{ crossenv, xorg-macros, xorgproto, libxcb, xtrans }:
 
 let
-  version = "1.6.5";
+  version = "1.6.7";
 
   name = "libx11-${version}";
 
   src = crossenv.nixpkgs.fetchurl {
-    url = "https://xorg.freedesktop.org/releases/individual/libX11-${version}.tar.bz2";
-    sha256 = "0pa3cfp6h9rl2vxmkph65250gfqyki0ccqyaan6bl9d25gdr0f2d";
+    url = "https://xorg.freedesktop.org/releases/individual/lib/libX11-${version}.tar.gz";
+    sha256 = "1lara6j4qcmflya34spyhj009n3fpdanlwiqqcfmxdc75a6bhapn";
   };
 
   lib = crossenv.make_derivation rec {
@@ -24,15 +23,12 @@ let
 
     cross_inputs = [
       xorg-macros
-      xproto
+      xorgproto
       libxcb
       xtrans
-      xextproto
-      inputproto
-      kbproto
     ];
 
-    inherit kbproto xproto libxcb;
+    inherit xorgproto libxcb;
   };
 
   license = crossenv.native.make_derivation {
@@ -43,12 +39,9 @@ let
 
   license_set =
     xorg-macros.license_set //
-    xproto.license_set //
+    xorgproto.license_set //
     libxcb.license_set //
     xtrans.license_set //
-    xextproto.license_set //
-    inputproto.license_set //
-    kbproto.license_set //
     { "${name}" = license; };
 
 in

--- a/nix/nixcrpkgs/pkgs/libxall/default.nix
+++ b/nix/nixcrpkgs/pkgs/libxall/default.nix
@@ -1,5 +1,5 @@
 # Amalgamates all of our X libraries into one derivation to make it easier to
-# build projects like Qt that expect them all to be installed in one place.
+# build projects that use a lot of them.
 
 { crossenv, libs }:
 

--- a/nix/nixcrpkgs/pkgs/libxau/builder.sh
+++ b/nix/nixcrpkgs/pkgs/libxau/builder.sh
@@ -13,4 +13,4 @@ make
 
 make install
 
-ln -s $xproto/lib/pkgconfig/xproto.pc $out/lib/pkgconfig/
+ln -s $xorgproto/lib/pkgconfig/xproto.pc $out/lib/pkgconfig/

--- a/nix/nixcrpkgs/pkgs/libxau/default.nix
+++ b/nix/nixcrpkgs/pkgs/libxau/default.nix
@@ -1,4 +1,4 @@
-{ crossenv, xorg-macros, xproto }:
+{ crossenv, xorg-macros, xorgproto }:
 
 let
   version = "1.0.8";
@@ -20,9 +20,9 @@ let
       "--enable-static " +
       "--disable-shared";
 
-    cross_inputs = [ xorg-macros xproto ];
+    cross_inputs = [ xorg-macros xorgproto ];
 
-    inherit xproto;
+    inherit xorgproto;
   };
 
   license = crossenv.native.make_derivation {
@@ -33,7 +33,7 @@ let
 
   license_set =
     xorg-macros.license_set //
-    xproto.license_set //
+    xorgproto.license_set //
     { "${name}" = license; };
 
 in

--- a/nix/nixcrpkgs/pkgs/libxcb/default.nix
+++ b/nix/nixcrpkgs/pkgs/libxcb/default.nix
@@ -1,13 +1,13 @@
 { crossenv, xcb-proto, libxau }:
 
 let
-  version = "1.12";
+  version = "1.13.1";
 
   name = "libxcb-${version}";
 
   src = crossenv.nixpkgs.fetchurl {
     url = "https://xcb.freedesktop.org/dist/libxcb-${version}.tar.bz2";
-    sha256 = "0nvv0la91cf8p5qqlb3r5xnmg1jn2wphn4fb5jfbr6byqsvv3psa";
+    sha256 = "1i27lvrcsygims1pddpl5c4qqs6z715lm12ax0n3vx0igapvg7x8";
   };
 
   lib = crossenv.make_derivation rec {

--- a/nix/nixcrpkgs/pkgs/libxext/builder.sh
+++ b/nix/nixcrpkgs/pkgs/libxext/builder.sh
@@ -15,5 +15,5 @@ make install
 
 sed -i 's/Requires.private/Requires/' $out/lib/pkgconfig/*.pc
 
-ln -sf $xextproto/lib/pkgconfig/*.pc $out/lib/pkgconfig/
+ln -sf $xorgproto/lib/pkgconfig/*.pc $out/lib/pkgconfig/
 ln -sf $libx11/lib/pkgconfig/*.pc $out/lib/pkgconfig/

--- a/nix/nixcrpkgs/pkgs/libxext/default.nix
+++ b/nix/nixcrpkgs/pkgs/libxext/default.nix
@@ -1,4 +1,4 @@
-{ crossenv, xproto, libx11, xextproto }:
+{ crossenv, xorgproto, libx11 }:
 
 let
   version = "1.3.3";
@@ -21,9 +21,9 @@ let
       "--enable-static " +
       "--disable-shared";
 
-    cross_inputs = [ xproto libx11 xextproto ];
+    cross_inputs = [ xorgproto libx11 ];
 
-    inherit xextproto libx11;
+    inherit xorgproto libx11;
   };
 
   license = crossenv.native.make_derivation {
@@ -33,9 +33,8 @@ let
   };
 
   license_set =
-    xproto.license_set //
+    xorgproto.license_set //
     libx11.license_set //
-    xextproto.license_set //
     { "${name}" = license; };
 
 in

--- a/nix/nixcrpkgs/pkgs/libxfixes/builder.sh
+++ b/nix/nixcrpkgs/pkgs/libxfixes/builder.sh
@@ -15,6 +15,5 @@ make install
 
 sed -i 's/Requires.private/Requires/' $out/lib/pkgconfig/*.pc
 
-ln -sf $xproto/lib/pkgconfig/*.pc $out/lib/pkgconfig/
-ln -sf $fixesproto/lib/pkgconfig/*.pc $out/lib/pkgconfig/
+ln -sf $xorgproto/lib/pkgconfig/*.pc $out/lib/pkgconfig/
 ln -sf $libx11/lib/pkgconfig/*.pc $out/lib/pkgconfig/

--- a/nix/nixcrpkgs/pkgs/libxfixes/default.nix
+++ b/nix/nixcrpkgs/pkgs/libxfixes/default.nix
@@ -1,4 +1,4 @@
-{ crossenv, xproto, xextproto, libx11, fixesproto }:
+{ crossenv, xorgproto, libx11 }:
 
 let
   version = "5.0.3";
@@ -20,9 +20,9 @@ let
       "--enable-static " +
       "--disable-shared";
 
-    cross_inputs = [ xproto xextproto libx11 fixesproto ];
+    cross_inputs = [ xorgproto libx11 ];
 
-    inherit xproto libx11 fixesproto;
+    inherit xorgproto libx11;
   };
 
   license = crossenv.native.make_derivation {
@@ -32,10 +32,8 @@ let
   };
 
   license_set =
-    xproto.license_set //
-    xextproto.license_set //
+    xorgproto.license_set //
     libx11.license_set //
-    fixesproto.license_set //
     { "${name}" = license; };
 
 in

--- a/nix/nixcrpkgs/pkgs/libxi/builder.sh
+++ b/nix/nixcrpkgs/pkgs/libxi/builder.sh
@@ -15,7 +15,7 @@ make install
 
 sed -i 's/Requires.private/Requires/' $out/lib/pkgconfig/*.pc
 
-ln -sf $inputproto/lib/pkgconfig/*.pc $out/lib/pkgconfig/
+ln -sf $xorgproto/lib/pkgconfig/*.pc $out/lib/pkgconfig/
 ln -sf $libx11/lib/pkgconfig/*.pc $out/lib/pkgconfig/
 ln -sf $libxext/lib/pkgconfig/*.pc $out/lib/pkgconfig/
 ln -sf $libxfixes/lib/pkgconfig/*.pc $out/lib/pkgconfig/

--- a/nix/nixcrpkgs/pkgs/libxi/default.nix
+++ b/nix/nixcrpkgs/pkgs/libxi/default.nix
@@ -1,4 +1,4 @@
-{ crossenv, xproto, xextproto, inputproto, libx11, libxext, libxfixes }:
+{ crossenv, xorgproto, libx11, libxext, libxfixes }:
 
 let
   version = "1.7.9";
@@ -21,9 +21,9 @@ let
       "--enable-static " +
       "--disable-shared";
 
-    cross_inputs = [ xproto xextproto inputproto libx11 libxext libxfixes ];
+    cross_inputs = [ xorgproto libx11 libxext libxfixes ];
 
-    inherit inputproto libx11 libxext libxfixes;
+    inherit xorgproto libx11 libxext libxfixes;
   };
 
   license = crossenv.native.make_derivation {
@@ -33,9 +33,7 @@ let
   };
 
   license_set =
-    xproto.license_set //
-    xextproto.license_set //
-    inputproto.license_set //
+    xorgproto.license_set //
     libx11.license_set //
     libxext.license_set //
     libxfixes.license_set //

--- a/nix/nixcrpkgs/pkgs/libxkbcommon/builder.sh
+++ b/nix/nixcrpkgs/pkgs/libxkbcommon/builder.sh
@@ -1,0 +1,21 @@
+source $setup
+
+tar -xf $src
+mv libxkbcommon-* libxkbcommon
+
+mkdir build
+cd build
+
+meson-cross . ../libxkbcommon \
+  --prefix $out \
+  --buildtype release \
+  --default-library static \
+  -Denable-wayland=false \
+  -Denable-docs=false
+
+ninja
+
+# Workaround for static builds being broken.
+mv libxkbcommon-x11-internal.a libxkbcommon-x11.a
+
+ninja install

--- a/nix/nixcrpkgs/pkgs/libxkbcommon/default.nix
+++ b/nix/nixcrpkgs/pkgs/libxkbcommon/default.nix
@@ -1,0 +1,40 @@
+{ crossenv, libxcb }:
+
+let
+  version = "0.8.3";
+
+  name = "libxkbcommon-${version}";
+
+  nixpkgs = crossenv.nixpkgs;
+
+  src = nixpkgs.fetchurl {
+    url = "https://github.com/xkbcommon/libxkbcommon/archive/xkbcommon-${version}.tar.gz";
+    sha256 = "0schaliwd5garrq3w7c8bg2cpnyr0ijg7583m3q2517iyqis9zmf";
+  };
+
+  lib = crossenv.make_derivation rec {
+    inherit version name src;
+
+    builder = ./builder.sh;
+
+    configure_flags =
+      "--host=${crossenv.host} " +
+      "--enable-static " +
+      "--disable-shared";
+
+    cross_inputs = [ libxcb ];
+
+    native_inputs = [ nixpkgs.meson nixpkgs.bison ];
+  };
+
+  license = crossenv.native.make_derivation {
+    name = "${name}-license";
+    inherit src;
+    builder = ./license_builder.sh;
+  };
+
+  license_set =
+    { "${name}" = license; };
+
+in
+  lib // { inherit license_set; }

--- a/nix/nixcrpkgs/pkgs/libxkbcommon/license_builder.sh
+++ b/nix/nixcrpkgs/pkgs/libxkbcommon/license_builder.sh
@@ -1,0 +1,14 @@
+source $setup
+
+tar -xf $src
+mv libxkbcommon-* libxkbcommon
+
+license=$(cat libxkbcommon/LICENSE)
+
+cat > $out <<EOF
+<h2>libxkbcommon</h2>
+
+<pre>
+$license
+</pre>
+EOF

--- a/nix/nixcrpkgs/pkgs/openocd/builder.sh
+++ b/nix/nixcrpkgs/pkgs/openocd/builder.sh
@@ -4,6 +4,10 @@ cp -r $src openocd
 chmod -R u+w openocd
 
 cd openocd
+for patch in $patches; do
+  echo applying patch $patch
+  patch -p1 -i $patch
+done
 SKIP_SUBMODULE=1 ./bootstrap
 cd ..
 
@@ -21,4 +25,4 @@ make
 
 make install
 
-$host-strip $out/bin/openocd
+$host-strip $out/bin/openocd$exe_suffix

--- a/nix/nixcrpkgs/pkgs/openocd/default.nix
+++ b/nix/nixcrpkgs/pkgs/openocd/default.nix
@@ -1,7 +1,7 @@
 { crossenv, libusb }:
 
 let
-  version = "2018-08-16";
+  version = "2018-09-19";
 
   name = "openocd-${version}";
 
@@ -10,8 +10,8 @@ let
   src = nixpkgs.fetchgit {
     url = "git://repo.or.cz/openocd";  # official mirror
     rev = "b2d259f67cc3ee4b689e704228d97943bae94064";
-    sha256 = "0c5zpjplwp0ivl4mpiix628j0iad9gkmg9f7lidgqjr5a80cr6hg";
-    deepClone = true;
+    sha256 = "126zcgq3dplhzmy28rqp0y0df92xgb2qkh9nfc70mka7jwj994yx";
+    fetchSubmodules = true;
   };
 
   drv = crossenv.make_derivation {
@@ -27,10 +27,16 @@ let
 
     ACLOCAL_PATH =
       "${nixpkgs.libtool}/share/aclocal:" +
-      "${crossenv.native.pkgconf}/share/aclocal";
+      "${nixpkgs.pkgconfig}/share/aclocal";
 
     # Avoid a name conflict: get_home_dir is also defined in libudev.
     CFLAGS = "-Dget_home_dir=openocd_get_home_dir";
+
+    patches = [
+      # Make sure the linker arguments needed by our static build of libusb
+      # get used when compiling the openocd executable.
+      ./ldflags.patch
+    ];
 
     cross_inputs = [ libusb ];
   };

--- a/nix/nixcrpkgs/pkgs/openocd/ldflags.patch
+++ b/nix/nixcrpkgs/pkgs/openocd/ldflags.patch
@@ -1,0 +1,11 @@
+--- a/src/Makefile.am
++++ b/src/Makefile.am
+@@ -12,6 +12,8 @@ bin_PROGRAMS += %D%/openocd
+
+ %C%_openocd_LDADD += $(MINGWLDADD)
+
++%C%_openocd_LDFLAGS = $(LIBUSB1_LIBS)
++
+ if INTERNAL_JIMTCL
+ %C%_openocd_LDADD += $(top_builddir)/jimtcl/libjim.a
+ else

--- a/nix/nixcrpkgs/pkgs/openssl/builder.sh
+++ b/nix/nixcrpkgs/pkgs/openssl/builder.sh
@@ -35,6 +35,8 @@ esac
 #
 # [2]: https://github.com/rust-embedded/cross/pull/218/files
 
+sed -i "1s|usr|$coreutils|" ../openssl-$version/Configure
+
 ../openssl-$version/Configure   \
   --prefix=$out                 \
   --cross-compile-prefix=$host- \

--- a/nix/nixcrpkgs/pkgs/openssl/default.nix
+++ b/nix/nixcrpkgs/pkgs/openssl/default.nix
@@ -6,6 +6,8 @@ crossenv.make_derivation rec {
 
     native_inputs = [ crossenv.nixpkgs.perl ];
 
+    coreutils = crossenv.nixpkgs.coreutils;
+
     src = crossenv.nixpkgs.fetchurl {
       url = "https://www.openssl.org/source/${name}.tar.gz";
       sha256 = "0gbab2fjgms1kx5xjvqx8bxhr98k4r8l2fa8vw7kvh491xd8fdi8";

--- a/nix/nixcrpkgs/pkgs/p-load/default.nix
+++ b/nix/nixcrpkgs/pkgs/p-load/default.nix
@@ -3,11 +3,11 @@
 crossenv.make_derivation rec {
   name = "p-load-${version}";
 
-  version = "2041b02";  # 2.1.0ish
+  version = "2.4.0";
 
   src = crossenv.nixpkgs.fetchurl {
     url = "https://github.com/pololu/p-load/archive/${version}.tar.gz";
-    sha256 = "07xn0k96pkvirsh45zn9976lwliiqkfx76vy1yrbx6kp55ssp2zp";
+    sha256 = "0z4acrm6spyz7dqzqdcba0shi6x01wpdnx8cin2pf29n28jwr2xc";
   };
 
   builder = ./builder.sh;

--- a/nix/nixcrpkgs/pkgs/qt/absolute-paths.patch
+++ b/nix/nixcrpkgs/pkgs/qt/absolute-paths.patch
@@ -1,6 +1,6 @@
-diff -ur qtbase-opensource-src-5.9.2-orig/configure qtbase-opensource-src-5.9.2/configure
---- qtbase-opensource-src-5.9.2-orig/configure	2017-10-26 08:10:12.932646805 -0700
-+++ qtbase-opensource-src-5.9.2/configure	2017-11-01 08:48:44.973917507 -0700
+diff -ur qtbase-everywhere-src-5.11.2-orig/configure qtbase-everywhere-src-5.11.2/configure
+--- qtbase-everywhere-src-5.11.2-orig/configure	2018-10-23 21:31:56.778237724 -0700
++++ qtbase-everywhere-src-5.11.2/configure	2018-10-23 21:33:31.412709225 -0700
 @@ -36,9 +36,9 @@
  relconf=`basename $0`
  # the directory of this script is the "source tree"
@@ -35,7 +35,7 @@ diff -ur qtbase-opensource-src-5.9.2-orig/configure qtbase-opensource-src-5.9.2/
  UNAME_SYSTEM=`(uname -s) 2>/dev/null`  || UNAME_SYSTEM=unknown
  
  BUILD_ON_MAC=no
--if [ -d /System/Library/Frameworks/Carbon.framework ]; then
+-if [ -d /System/Library/Frameworks/Cocoa.framework ]; then
 -    BUILD_ON_MAC=yes
 -fi
  if [ "$OSTYPE" = "msys" ]; then

--- a/nix/nixcrpkgs/pkgs/qt/builder.sh
+++ b/nix/nixcrpkgs/pkgs/qt/builder.sh
@@ -3,12 +3,14 @@ source $setup
 mkdir -p $out
 pushd $out
 tar -xf $src
-mv qtbase-opensource-src-* src
+mv qtbase-everywhere-src-* src
 cd src
 for patch in $patches; do
   echo applying patch $patch
   patch -p1 -i $patch
 done
+cd src/3rdparty
+rm -r angle xcb
 popd
 
 mkdir build

--- a/nix/nixcrpkgs/pkgs/qt/dont-test-uxtheme.patch
+++ b/nix/nixcrpkgs/pkgs/qt/dont-test-uxtheme.patch
@@ -1,7 +1,6 @@
-diff -ur qtbase-opensource-src-5.9.2-orig/src/widgets/configure.json qtbase-opensource-src-5.9.2/src/widgets/configure.json
---- qtbase-opensource-src-5.9.2-orig/src/widgets/configure.json	2017-10-25 13:52:49.173421900 -0700
-+++ qtbase-opensource-src-5.9.2/src/widgets/configure.json	2017-10-25 13:53:42.891341214 -0700
-@@ -28,11 +28,6 @@
+--- qtbase-everywhere-src-5.12.0-orig/src/widgets/configure.json
++++ qtbase-everywhere-src-5.12.0/src/widgets/configure.json
+@@ -27,11 +27,6 @@
      },
  
      "tests": {
@@ -13,12 +12,12 @@ diff -ur qtbase-opensource-src-5.9.2-orig/src/widgets/configure.json qtbase-open
      },
  
      "features": {
-@@ -57,7 +52,7 @@
-         },
-         "style-windowsxp": {
-             "label": "WindowsXP",
--            "condition": "features.style-windows && config.win32 && !config.winrt && tests.uxtheme",
-+            "condition": "features.style-windows && config.win32 && !config.winrt",
-             "output": [ "privateFeature", "styles" ]
+@@ -56,7 +51,7 @@
          },
          "style-windowsvista": {
+             "label": "WindowsVista",
+-            "condition": "features.style-windows && features.animation && config.win32 && !config.winrt && tests.uxtheme",
++            "condition": "features.style-windows && features.animation && config.win32 && !config.winrt",
+             "output": [ "privateFeature", "styles" ]
+         },
+         "style-android": {

--- a/nix/nixcrpkgs/pkgs/qt/examples_builder.sh
+++ b/nix/nixcrpkgs/pkgs/qt/examples_builder.sh
@@ -9,11 +9,17 @@ mkdir bin moc obj
 cat > obj/plugins.cpp <<EOF
 #include <QtPlugin>
 #ifdef _WIN32
-Q_IMPORT_PLUGIN (QWindowsIntegrationPlugin);
+Q_IMPORT_PLUGIN(QWindowsIntegrationPlugin)
+#if QT_VERSION >= QT_VERSION_CHECK(5, 10, 0)
+Q_IMPORT_PLUGIN(QWindowsVistaStylePlugin)
+#endif
 #endif
 #ifdef __linux__
-Q_IMPORT_PLUGIN (QLinuxFbIntegrationPlugin);
-Q_IMPORT_PLUGIN (QXcbIntegrationPlugin);
+Q_IMPORT_PLUGIN(QLinuxFbIntegrationPlugin)
+Q_IMPORT_PLUGIN(QXcbIntegrationPlugin)
+#endif
+#ifdef __APPLE__
+Q_IMPORT_PLUGIN(QCocoaIntegrationPlugin)
 #endif
 EOF
 
@@ -69,17 +75,15 @@ if [ $os != "linux" ]; then
     $examples/gui/openglwindow/openglwindow.cpp \
     moc/openglwindow.cpp \
     obj/plugins.o \
-  $LIBS -o bin/openglwindow$exe_suffix
+   $LIBS -o bin/openglwindow$exe_suffix
 fi
-
-# TODO: try to compile some stuff with $qtbase/bin/qmake too, make sure that works
 
 mkdir -p $out/bin
 
 for prog in analogclock dynamiclayouts openglwindow rasterwindow; do
-  if [ -f bin/$prog ]; then
-    $host-strip bin/$prog
-    cp bin/$prog $out/bin/
+  if [ -f bin/$prog$exe_suffix ]; then
+    $host-strip bin/$prog$exe_suffix
+    cp bin/$prog$exe_suffix $out/bin/
   fi
 done
 

--- a/nix/nixcrpkgs/pkgs/qt/find-x11.patch
+++ b/nix/nixcrpkgs/pkgs/qt/find-x11.patch
@@ -1,0 +1,48 @@
+diff -ur qtbase-everywhere-src-5.12.1-orig/src/gui/configure.json qtbase-everywhere-src-5.12.1/src/gui/configure.json
+--- qtbase-everywhere-src-5.12.1-orig/src/gui/configure.json	2019-01-28 09:11:52.000000000 -0800
++++ qtbase-everywhere-src-5.12.1/src/gui/configure.json	2019-02-05 09:51:36.758000000 -0800
+@@ -572,6 +572,13 @@
+                 { "type": "pkgConfig", "args": "sm ice" }
+             ]
+         },
++        "x11": {
++            "label": "libx11",
++            "headers": "X11/cursorfont.h",
++            "sources": [
++                { "type": "pkgConfig", "args": "x11" }
++            ]
++        },
+         "xcb": {
+             "label": "XCB >= 1.9",
+             "test": {
+@@ -1066,7 +1073,8 @@
+                     "xcb/xfixes.h",
+                     "xcb/xinerama.h",
+                     "xcb/xcb_icccm.h",
+-                    "xcb/xcb_renderutil.h"
++                    "xcb/xcb_renderutil.h",
++                    "X11/cursorfont.h"
+                 ],
+                 "main": [
+                     "int primaryScreen = 0;",
+@@ -1083,7 +1091,7 @@
+                     "xcb_render_util_find_standard_format(nullptr, XCB_PICT_STANDARD_ARGB_32);"
+                 ]
+             },
+-            "use": "xcb_icccm xcb_image xcb_keysyms xcb_randr xcb_render xcb_renderutil xcb_shape xcb_shm xcb_sync xcb_xfixes xcb_xinerama xcb"
++            "use": "xcb_icccm xcb_image xcb_keysyms xcb_randr xcb_render xcb_renderutil xcb_shape xcb_shm xcb_sync xcb_xfixes xcb_xinerama xcb x11"
+         },
+         "x11prefix": {
+             "label": "X11 prefix",
+diff -ur qtbase-everywhere-src-5.12.1-orig/src/plugins/platforms/xcb/xcb_qpa_lib.pro qtbase-everywhere-src-5.12.1/src/plugins/platforms/xcb/xcb_qpa_lib.pro
+--- qtbase-everywhere-src-5.12.1-orig/src/plugins/platforms/xcb/xcb_qpa_lib.pro	2019-01-28 09:11:52.000000000 -0800
++++ qtbase-everywhere-src-5.12.1/src/plugins/platforms/xcb/xcb_qpa_lib.pro	2019-02-05 09:54:14.474000000 -0800
+@@ -67,6 +67,8 @@
+ 
+ DEFINES += QT_BUILD_XCB_PLUGIN
+ 
++QMAKE_USE += x11
++
+ qtConfig(xcb-xlib) {
+     QMAKE_USE += xcb_xlib
+ }

--- a/nix/nixcrpkgs/pkgs/qt/license_builder.sh
+++ b/nix/nixcrpkgs/pkgs/qt/license_builder.sh
@@ -2,8 +2,9 @@
 
 source $setup
 
-if [ "$version" != "5.9.6" ]; then
+if [ "$version" != "5.12.4" ]; then
   echo "You need to update the license fragment builder for Qt $version."
+  echo "(Check for new third-party libraries.)"
   exit 1
 fi
 
@@ -15,9 +16,8 @@ mv qtbase-* qtbase
 license_qt=$(cat qtbase/LICENSE.LGPLv3)
 cd qtbase/src/3rdparty
 license_android=$(cat android/LICENSE)
-license_angle1=$(cat angle/LICENSE)
-license_angle2=$(cat angle/TRACEEVENT_LICENSE)
-license_angle3=$(cat angle/SYSTEMINFO_LICENSE)
+# angle: we don't use it
+# dbus-ifaces: just some XML files, no license
 license_dc=$(cat double-conversion/LICENSE)
 license_easing=$(cat easing/LICENSE)
 license_forkfd=$(cat forkfd/LICENSE)
@@ -27,15 +27,22 @@ license_gradle=$(cat gradle/LICENSE-GRADLEW.txt)
 license_harfbuzz=$(cat harfbuzz/COPYING)
 license_harfbuzz_ng=$(cat harfbuzz-ng/COPYING)
 license_ia2=$(cat iaccessible2/LICENSE)
+license_icc=$(cat icc/LICENSE.txt)
 license_libjpeg=$(cat libjpeg/LICENSE)
 license_libpng=$(cat libpng/LICENSE)
+# md4: public domain
+# md5: public domain
 license_pcre2=$(cat pcre2/LICENCE)
 license_pixman=$(cat pixman/LICENSE)
 license_rfc6234=$(cat rfc6234/LICENSE)
+# sha1: public domain according to JSON file
 license_sha3_1=$(cat sha3/BRG_ENDIAN_LICENSE)
 license_sha3_2=$(cat sha3/CC0_LICENSE)
-license_xcb=$(cat xcb/LICENSE)
-license_xkbcommon=$(cat xkbcommon/COPYING)
+# sqlite: public domain
+license_tinycbor=$(cat tinycbor/LICENSE)
+# wasm: Stands for web assembly; we don't use it (yet)
+# wintab: No licensing restrictions according to LICENSE.txt.
+# xcb: Not used; it has its own nixcrpkgs package.
 license_zlib=$(cat zlib/LICENSE)
 
 cat > $out <<EOF
@@ -59,18 +66,6 @@ $license_qt
 
 <pre>
 $license_android
-</pre>
-
-<pre>
-$license_angle1
-</pre>
-
-<pre>
-$license_angle2
-</pre>
-
-<pre>
-$license_angle3
 </pre>
 
 <pre>
@@ -110,6 +105,10 @@ $license_ia2
 </pre>
 
 <pre>
+$license_icc
+</pre>
+
+<pre>
 $license_libjpeg
 </pre>
 
@@ -138,11 +137,7 @@ $license_sha3_2
 </pre>
 
 <pre>
-$license_xcb
-</pre>
-
-<pre>
-$license_xkbcommon
+$license_tinycbor
 </pre>
 
 <pre>

--- a/nix/nixcrpkgs/pkgs/qt/macos-config.patch
+++ b/nix/nixcrpkgs/pkgs/qt/macos-config.patch
@@ -1,20 +1,6 @@
-diff -ur qtbase-opensource-src-5.9.2-orig/mkspecs/common/clang.conf qtbase-opensource-src-5.9.2-mac/mkspecs/common/clang.conf
---- qtbase-opensource-src-5.9.2-orig/mkspecs/common/clang.conf	2017-11-03 20:37:01.001539490 -0700
-+++ qtbase-opensource-src-5.9.2-mac/mkspecs/common/clang.conf	2017-11-03 20:46:20.159382848 -0700
-@@ -4,8 +4,8 @@
- 
- QMAKE_COMPILER          = gcc clang llvm   # clang pretends to be gcc
- 
--QMAKE_CC                = clang
--QMAKE_CXX               = clang++
-+QMAKE_CC                = $${CROSS_COMPILE}clang
-+QMAKE_CXX               = $${CROSS_COMPILE}clang++
- 
- QMAKE_LINK_C            = $$QMAKE_CC
- QMAKE_LINK_C_SHLIB      = $$QMAKE_CC
-diff -ur qtbase-opensource-src-5.9.2-orig/mkspecs/common/clang-mac.conf qtbase-opensource-src-5.9.2-mac/mkspecs/common/clang-mac.conf
---- qtbase-opensource-src-5.9.2-orig/mkspecs/common/clang-mac.conf	2017-11-03 20:37:01.001539490 -0700
-+++ qtbase-opensource-src-5.9.2-mac/mkspecs/common/clang-mac.conf	2017-11-03 20:55:13.878575754 -0700
+diff -ur qtbase-everywhere-src-5.12.4-orig/mkspecs/common/clang-mac.conf qtbase-everywhere-src-5.12.4/mkspecs/common/clang-mac.conf
+--- qtbase-everywhere-src-5.12.4-orig/mkspecs/common/clang-mac.conf	2019-08-17 11:27:28.315000000 -0700
++++ qtbase-everywhere-src-5.12.4/mkspecs/common/clang-mac.conf	2019-08-17 11:28:33.791000000 -0700
 @@ -6,8 +6,6 @@
  
  QMAKE_XCODE_GCC_VERSION = com.apple.compilers.llvm.clang.1_0
@@ -24,29 +10,19 @@ diff -ur qtbase-opensource-src-5.9.2-orig/mkspecs/common/clang-mac.conf qtbase-o
  QMAKE_AR_LTCG  = libtool -static -o
  
  QMAKE_CFLAGS_APPLICATION_EXTENSION  = -fapplication-extension
-diff -ur qtbase-opensource-src-5.9.2-orig/mkspecs/common/mac.conf qtbase-opensource-src-5.9.2-mac/mkspecs/common/mac.conf
---- qtbase-opensource-src-5.9.2-orig/mkspecs/common/mac.conf	2017-11-03 20:37:01.001539490 -0700
-+++ qtbase-opensource-src-5.9.2-mac/mkspecs/common/mac.conf	2017-11-03 22:03:30.960602142 -0700
-@@ -35,10 +35,10 @@
+diff -ur qtbase-everywhere-src-5.12.4-orig/mkspecs/features/mac/default_post.prf qtbase-everywhere-src-5.12.4/mkspecs/features/mac/default_post.prf
+--- qtbase-everywhere-src-5.12.4-orig/mkspecs/features/mac/default_post.prf	2019-08-17 11:27:28.327000000 -0700
++++ qtbase-everywhere-src-5.12.4/mkspecs/features/mac/default_post.prf	2019-08-17 11:28:33.791000000 -0700
+@@ -3,7 +3,7 @@
+ contains(TEMPLATE, .*app) {
+     !macx-xcode:if(isEmpty(BUILDS)|build_pass) {
+         # Detect changes to the platform SDK
+-        QMAKE_EXTRA_VARIABLES += QMAKE_MAC_SDK QMAKE_MAC_SDK_VERSION QMAKE_XCODE_DEVELOPER_PATH
++        QMAKE_EXTRA_VARIABLES += QMAKE_MAC_SDK QMAKE_MAC_SDK_VERSION
+         QMAKE_EXTRA_INCLUDES += $$shell_quote($$PWD/sdk.mk)
+     }
  
- QMAKE_ACTOOL            = actool
- 
--QMAKE_DSYMUTIL          = dsymutil
--QMAKE_STRIP             = strip
-+QMAKE_DSYMUTIL          = $${CROSS_COMPILE}dsymutil
-+QMAKE_STRIP             = $${CROSS_COMPILE}strip
- QMAKE_STRIPFLAGS_LIB   += -S -x
- 
--QMAKE_AR                = ar cq
--QMAKE_RANLIB            = ranlib -s
--QMAKE_NM                = nm -P
-+QMAKE_AR                = $${CROSS_COMPILE}ar cq
-+QMAKE_RANLIB            = $${CROSS_COMPILE}ranlib -s
-+QMAKE_NM                = $${CROSS_COMPILE}nm -P
-diff -ur qtbase-opensource-src-5.9.2-orig/mkspecs/features/mac/default_post.prf qtbase-opensource-src-5.9.2-mac/mkspecs/features/mac/default_post.prf
---- qtbase-opensource-src-5.9.2-orig/mkspecs/features/mac/default_post.prf	2017-11-03 20:37:01.008206202 -0700
-+++ qtbase-opensource-src-5.9.2-mac/mkspecs/features/mac/default_post.prf	2017-11-03 21:06:25.247871399 -0700
-@@ -2,29 +2,6 @@
+@@ -41,29 +41,6 @@
  
  !no_objective_c:CONFIG += objective_c
  
@@ -76,7 +52,7 @@ diff -ur qtbase-opensource-src-5.9.2-orig/mkspecs/features/mac/default_post.prf 
  # Add the same default rpaths as Xcode does for new projects.
  # This is especially important for iOS/tvOS/watchOS where no other option is possible.
  !no_default_rpath {
-@@ -89,10 +66,6 @@
+@@ -151,10 +128,6 @@
  
      arch_flags = $(EXPORT_ARCH_ARGS)
  
@@ -87,19 +63,30 @@ diff -ur qtbase-opensource-src-5.9.2-orig/mkspecs/features/mac/default_post.prf 
      QMAKE_PCH_ARCHS = $$VALID_ARCHS
  
      macos: deployment_target = $$QMAKE_MACOSX_DEPLOYMENT_TARGET
-@@ -149,9 +122,6 @@
-         else: \
-             version_identifier = $$device.deployment_identifier
-         version_min_flag = -m$${version_identifier}-version-min=$$deployment_target
--        QMAKE_CFLAGS += -isysroot $$QMAKE_MAC_SDK_PATH $$version_min_flag
--        QMAKE_CXXFLAGS += -isysroot $$QMAKE_MAC_SDK_PATH $$version_min_flag
--        QMAKE_LFLAGS += -Wl,-syslibroot,$$QMAKE_MAC_SDK_PATH $$version_min_flag
-     }
+@@ -202,9 +175,6 @@
+                 QMAKE_XARCH_LFLAGS_$${arch}
+         }
  
-     # Enable precompiled headers for multiple architectures
-diff -ur qtbase-opensource-src-5.9.2-orig/mkspecs/features/mac/default_pre.prf qtbase-opensource-src-5.9.2-mac/mkspecs/features/mac/default_pre.prf
---- qtbase-opensource-src-5.9.2-orig/mkspecs/features/mac/default_pre.prf	2017-11-03 20:37:01.008206202 -0700
-+++ qtbase-opensource-src-5.9.2-mac/mkspecs/features/mac/default_pre.prf	2017-11-03 20:46:20.159382848 -0700
+-        QMAKE_CFLAGS += $(EXPORT_QMAKE_XARCH_CFLAGS)
+-        QMAKE_CXXFLAGS += $(EXPORT_QMAKE_XARCH_CFLAGS)
+-        QMAKE_LFLAGS += $(EXPORT_QMAKE_XARCH_LFLAGS)
+     } else {
+         simulator: \
+             version_identifier = $$simulator.deployment_identifier
+@@ -244,10 +214,6 @@
+     QMAKE_PCH_OUTPUT_EXT = _${QMAKE_PCH_ARCH}$${QMAKE_PCH_OUTPUT_EXT}
+ }
+ 
+-cache(QMAKE_XCODE_DEVELOPER_PATH, stash)
+-!isEmpty(QMAKE_XCODE_VERSION): \
+-    cache(QMAKE_XCODE_VERSION, stash)
+-
+ QMAKE_XCODE_LIBRARY_SUFFIX = $$qtPlatformTargetSuffix()
+ 
+ xcode_product_bundle_identifier_setting.name = PRODUCT_BUNDLE_IDENTIFIER
+diff -ur qtbase-everywhere-src-5.12.4-orig/mkspecs/features/mac/default_pre.prf qtbase-everywhere-src-5.12.4/mkspecs/features/mac/default_pre.prf
+--- qtbase-everywhere-src-5.12.4-orig/mkspecs/features/mac/default_pre.prf	2019-08-17 11:27:28.327000000 -0700
++++ qtbase-everywhere-src-5.12.4/mkspecs/features/mac/default_pre.prf	2019-08-17 11:28:33.791000000 -0700
 @@ -1,43 +1,6 @@
  CONFIG = asset_catalogs rez $$CONFIG
  load(default_pre)
@@ -144,19 +131,32 @@ diff -ur qtbase-opensource-src-5.9.2-orig/mkspecs/features/mac/default_pre.prf q
  QMAKE_ASSET_CATALOGS_APP_ICON = AppIcon
  
  # Make the default debug info format for static debug builds
-diff -ur qtbase-opensource-src-5.9.2-orig/mkspecs/features/mac/sdk.prf qtbase-opensource-src-5.9.2-mac/mkspecs/features/mac/sdk.prf
---- qtbase-opensource-src-5.9.2-orig/mkspecs/features/mac/sdk.prf	2017-11-03 20:37:01.008206202 -0700
-+++ qtbase-opensource-src-5.9.2-mac/mkspecs/features/mac/sdk.prf	2017-11-03 20:46:20.159382848 -0700
+diff -ur qtbase-everywhere-src-5.12.4-orig/mkspecs/features/mac/sdk.mk qtbase-everywhere-src-5.12.4/mkspecs/features/mac/sdk.mk
+--- qtbase-everywhere-src-5.12.4-orig/mkspecs/features/mac/sdk.mk	2019-08-17 11:27:28.327000000 -0700
++++ qtbase-everywhere-src-5.12.4/mkspecs/features/mac/sdk.mk	2019-08-17 11:32:30.271000000 -0700
+@@ -1,7 +1,7 @@
+ 
+ ifeq ($(QT_MAC_SDK_NO_VERSION_CHECK),)
+-    CHECK_SDK_COMMAND = /usr/bin/xcrun --sdk $(EXPORT_QMAKE_MAC_SDK) -show-sdk-version 2>&1
+-    CURRENT_MAC_SDK_VERSION := $(shell DEVELOPER_DIR=$(EXPORT_QMAKE_XCODE_DEVELOPER_PATH) $(CHECK_SDK_COMMAND))
++    CHECK_SDK_COMMAND = false
++    CURRENT_MAC_SDK_VERSION := $(EXPORT_QMAKE_MAC_SDK_VERSION)
+     ifneq ($(CURRENT_MAC_SDK_VERSION),$(EXPORT_QMAKE_MAC_SDK_VERSION))
+         # We don't want to complain about out of date SDK unless the target needs to be remade.
+         # This covers use-cases such as running 'make check' after moving the build to a
+diff -ur qtbase-everywhere-src-5.12.4-orig/mkspecs/features/mac/sdk.prf qtbase-everywhere-src-5.12.4/mkspecs/features/mac/sdk.prf
+--- qtbase-everywhere-src-5.12.4-orig/mkspecs/features/mac/sdk.prf	2019-08-17 11:27:28.327000000 -0700
++++ qtbase-everywhere-src-5.12.4/mkspecs/features/mac/sdk.prf	2019-08-17 11:28:33.791000000 -0700
 @@ -18,7 +18,7 @@
          sdk = $$QMAKE_MAC_SDK
  
      isEmpty(QMAKE_MAC_SDK.$${sdk}.$${info}) {
--        QMAKE_MAC_SDK.$${sdk}.$${info} = $$system("/usr/bin/xcrun --sdk $$sdk $$info 2>/dev/null")
-+        QMAKE_MAC_SDK.$${sdk}.$${info} = $$system("xcrun --sdk $$sdk $$info 2>/dev/null")
+-        QMAKE_MAC_SDK.$${sdk}.$${info} = $$system("/usr/bin/xcrun --sdk $$sdk $$infoarg 2>/dev/null")
++        QMAKE_MAC_SDK.$${sdk}.$${info} = $$system("xcrun --sdk $$sdk $$infoarg 2>/dev/null")
          # --show-sdk-platform-path won't work for Command Line Tools; this is fine
          # only used by the XCTest backend to testlib
-         isEmpty(QMAKE_MAC_SDK.$${sdk}.$${info}):if(!isEmpty(QMAKE_XCODEBUILD_PATH)|!equals(info, "--show-sdk-platform-path")): \
-@@ -50,7 +50,7 @@
+         isEmpty(QMAKE_MAC_SDK.$${sdk}.$${info}):if(!isEmpty(QMAKE_XCODEBUILD_PATH)|!equals(infoarg, "--show-sdk-platform-path")): \
+@@ -53,7 +53,7 @@
      value = $$eval($$tool)
      isEmpty(value): next()
  

--- a/nix/nixcrpkgs/pkgs/qt/win32-link-object-max.patch
+++ b/nix/nixcrpkgs/pkgs/qt/win32-link-object-max.patch
@@ -1,7 +1,7 @@
-diff -ur qtbase-opensource-src-5.9.6-orig/mkspecs/win32-g++/qmake.conf qtbase-opensource-src-5.9.6/mkspecs/win32-g++/qmake.conf
---- qtbase-opensource-src-5.9.6-orig/mkspecs/win32-g++/qmake.conf	2018-06-19 12:41:49.061465695 -0700
-+++ qtbase-opensource-src-5.9.6/mkspecs/win32-g++/qmake.conf	2018-06-19 12:42:15.406453120 -0700
-@@ -54,10 +54,8 @@
+diff -ur qtbase-everywhere-src-5.11.2-orig/mkspecs/common/g++-win32.conf qtbase-everywhere-src-5.11.2/mkspecs/common/g++-win32.conf
+--- qtbase-everywhere-src-5.11.2-orig/mkspecs/common/g++-win32.conf	2018-10-23 21:31:56.864905432 -0700
++++ qtbase-everywhere-src-5.11.2/mkspecs/common/g++-win32.conf	2018-10-23 21:43:31.797114564 -0700
+@@ -48,10 +48,8 @@
  QMAKE_LFLAGS_WINDOWS    = -Wl,-subsystem,windows
  QMAKE_LFLAGS_DLL        = -shared
  QMAKE_LFLAGS_GCSECTIONS = -Wl,--gc-sections

--- a/nix/nixcrpkgs/pkgs/qt/wrapper_builder.rb
+++ b/nix/nixcrpkgs/pkgs/qt/wrapper_builder.rb
@@ -40,8 +40,9 @@ end
 # purely transitive.
 def make_dep_graph
   # High-level dependencies.
-  add_dep 'Qt5Widgets.x', 'libQt5Widgets.a'
-  add_dep 'Qt5Widgets.x', 'Qt5Gui.x'
+  add_dep 'Qt5Widgets.x', 'Qt5WidgetsNoPlugins.x'
+  add_dep 'Qt5WidgetsNoPlugins.x', 'libQt5Widgets.a'
+  add_dep 'Qt5WidgetsNoPlugins.x', 'Qt5Gui.x'
   add_dep 'Qt5Gui.x', 'Qt5GuiNoPlugins.x'
   add_dep 'Qt5GuiNoPlugins.x', 'libQt5Gui.a'
   add_dep 'Qt5GuiNoPlugins.x', 'Qt5Core.x'
@@ -50,8 +51,8 @@ def make_dep_graph
   # Include directories.
   add_dep 'Qt5Core.x', '-I' + OutIncDir.to_s
   add_dep 'Qt5Core.x', '-I' + (OutIncDir + 'QtCore').to_s
-  add_dep 'Qt5Gui.x', '-I' + (OutIncDir + 'QtGui').to_s
-  add_dep 'Qt5Widgets.x', '-I' + (OutIncDir + 'QtWidgets').to_s
+  add_dep 'Qt5GuiNoPlugins.x', '-I' + (OutIncDir + 'QtGui').to_s
+  add_dep 'Qt5WidgetsNoPlugins.x', '-I' + (OutIncDir + 'QtWidgets').to_s
 
   # Libraries that Qt depends on.
   add_dep 'libQt5Widgets.a', 'libQt5Gui.a'
@@ -63,25 +64,34 @@ def make_dep_graph
 
   if Os == 'windows'
     add_dep 'Qt5Gui.x', 'qwindows.x'
+
     add_dep 'qwindows.x', 'libqwindows.a'
 
     add_dep 'libqwindows.a', '-ldwmapi'
     add_dep 'libqwindows.a', '-limm32'
     add_dep 'libqwindows.a', '-loleaut32'
+    add_dep 'libqwindows.a', '-lwtsapi32'
     add_dep 'libqwindows.a', 'libQt5Gui.a'
     add_dep 'libqwindows.a', 'libQt5EventDispatcherSupport.a'
     add_dep 'libqwindows.a', 'libQt5FontDatabaseSupport.a'
     add_dep 'libqwindows.a', 'libQt5ThemeSupport.a'
+    add_dep 'libqwindows.a', 'libQt5WindowsUIAutomationSupport.a'
 
+    add_dep 'Qt5Widgets.x', 'qwindowsvistastyle.x'
+    add_dep 'qwindowsvistastyle.x', 'libqwindowsvistastyle.a'
+
+    add_dep 'libqwindowsvistastyle.a', '-luxtheme'
+    add_dep 'libqwindowsvistastyle.a', 'libQt5Widgets.a'
+
+    add_dep 'libQt5Core.a', '-lnetapi32'
     add_dep 'libQt5Core.a', '-lole32'
+    add_dep 'libQt5Core.a', '-luserenv'
     add_dep 'libQt5Core.a', '-luuid'
     add_dep 'libQt5Core.a', '-lversion'
     add_dep 'libQt5Core.a', '-lwinmm'
     add_dep 'libQt5Core.a', '-lws2_32'
 
     add_dep 'libQt5Gui.a', '-lopengl32'
-
-    add_dep 'libQt5Widgets.a', '-luxtheme'
   end
 
   if Os == 'linux'
@@ -104,6 +114,7 @@ def make_dep_graph
     add_dep 'libQt5LinuxAccessibilitySupport.a', 'xcb-aux.pc'
     add_dep 'libQt5ThemeSupport.a', 'libQt5DBus.a'
 
+    add_dep 'libQt5XcbQpa.a', 'libQt5EdidSupport.a'
     add_dep 'libQt5XcbQpa.a', 'libQt5EventDispatcherSupport.a'
     add_dep 'libQt5XcbQpa.a', 'libQt5FontDatabaseSupport.a'
     add_dep 'libQt5XcbQpa.a', 'libQt5Gui.a'
@@ -123,8 +134,11 @@ def make_dep_graph
     add_dep 'libQt5XcbQpa.a', 'xcb-sync.pc'
     add_dep 'libQt5XcbQpa.a', 'xcb-xfixes.pc'
     add_dep 'libQt5XcbQpa.a', 'xcb-xinerama.pc'
+    add_dep 'libQt5XcbQpa.a', 'xcb-xinput.pc'
     add_dep 'libQt5XcbQpa.a', 'xcb-xkb.pc'
     add_dep 'libQt5XcbQpa.a', 'xi.pc'
+    add_dep 'libQt5XcbQpa.a', 'xkbcommon.pc'
+    add_dep 'libQt5XcbQpa.a', 'xkbcommon-x11.pc'
   end
 
   if Os == 'macos'
@@ -132,20 +146,25 @@ def make_dep_graph
     add_dep 'qcocoa.x', 'libqcocoa.a'
 
     add_dep 'libqcocoa.a', 'libcocoaprintersupport.a'
-    add_dep 'libqcocoa.a', '-lcups'  # Also available: -lcups.2
     add_dep 'libqcocoa.a', 'libQt5AccessibilitySupport.a'
     add_dep 'libqcocoa.a', 'libQt5ClipboardSupport.a'
-    add_dep 'libqcocoa.a', 'libQt5CglSupport.a'
     add_dep 'libqcocoa.a', 'libQt5GraphicsSupport.a'
     add_dep 'libqcocoa.a', 'libQt5FontDatabaseSupport.a'
     add_dep 'libqcocoa.a', 'libQt5ThemeSupport.a'
     add_dep 'libqcocoa.a', 'libQt5PrintSupport.a'
+    add_dep 'libqcocoa.a', '-lcups'  # Also available: -lcups.2
+    add_dep 'libqcocoa.a', '-framework IOKit'
+    add_dep 'libqcocoa.a', '-framework IOSurface'
+    add_dep 'libqcocoa.a', '-framework CoreVideo'
+    add_dep 'libqcocoa.a', '-framework Metal'
+    add_dep 'libqcocoa.a', '-framework QuartzCore'
 
     add_dep 'libqtlibpng.a', '-lz'
 
     add_dep 'libQt5Core.a', '-lobjc'
     add_dep 'libQt5Core.a', '-framework CoreServices'
     add_dep 'libQt5Core.a', '-framework CoreText'
+    add_dep 'libQt5Core.a', '-framework Security'
     add_dep 'libQt5Gui.a', '-framework CoreGraphics'
     add_dep 'libQt5Gui.a', '-framework OpenGL'
     add_dep 'libQt5Widgets.a', '-framework Carbon'
@@ -333,10 +352,13 @@ def create_pc_file(name)
     end
   end
 
+  pkg_name = Pathname(name).sub_ext('').to_s
+
   r = ""
   r << "prefix=#{OutDir}\n"
   r << "libdir=${prefix}/lib\n"
   r << "includedir=${prefix}/include\n"
+  r << "Name: #{pkg_name}\n"
   r << "Version: #{QtVersionString}\n"
   if !libdirs.empty? || !ldflags.empty?
     r << "Libs: #{libdirs.reverse.uniq.join(' ')} #{ldflags.reverse.join(' ')}\n"
@@ -348,8 +370,8 @@ def create_pc_file(name)
     r << "Requires: #{requires.sort.join(' ')}\n"
   end
 
-  path = OutPcDir + Pathname(name).sub_ext(".pc")
-  File.open(path.to_s, 'w') do |f|
+  path = OutPcDir + (pkg_name + ".pc")
+  File.open(path, 'w') do |f|
     f.write r
   end
 end

--- a/nix/nixcrpkgs/pkgs/tic/default.nix
+++ b/nix/nixcrpkgs/pkgs/tic/default.nix
@@ -3,11 +3,11 @@
 crossenv.make_derivation rec {
   name = "tic-${version}";
 
-  version = "e1693cd";  # 1.5.0ish
+  version = "1.7.0";
 
   src = crossenv.nixpkgs.fetchurl {
     url = "https://github.com/pololu/pololu-tic-software/archive/${version}.tar.gz";
-    sha256 = "07m75w0walr61yqki7h1ipzbfz7x417g7qnx0p1l6qdz89fyc7i8";
+    sha256 = "1k091i6sz5j204xrq12x97ixj56bjwbb593lp7j3qf94msj7sff9";
   };
 
   builder = ./builder.sh;

--- a/nix/nixcrpkgs/pkgs/usbview/default.nix
+++ b/nix/nixcrpkgs/pkgs/usbview/default.nix
@@ -5,13 +5,13 @@ if crossenv.os != "windows" then "windows only" else
 crossenv.make_derivation rec {
   name = "usbview-${version}";
 
-  version = "2017-05-01";
+  version = "2019-01-24";
 
   src = crossenv.nixpkgs.fetchFromGitHub {
     owner = "Microsoft";
     repo = "Windows-driver-samples";
-    rev = "4c5c5e0297c7a61e151f92af702cdac650a14489";
-    sha256 = "1drq26bnad98xqn805qx0b6g4y65lmrdj7v40b3jhhzdsp8993pf";
+    rev = "39d39e7485faddf601d51c897863ff2f876e391e";
+    sha256 = "0nyw3wzlh68zxpb0ydzkgpf5c83scapfp6zsc5gahxlcgrhy3xwj";
   };
 
   patches = [ ./megapatch.patch ];

--- a/nix/nixcrpkgs/pkgs/xcb-proto/default.nix
+++ b/nix/nixcrpkgs/pkgs/xcb-proto/default.nix
@@ -1,13 +1,13 @@
 { crossenv }:
 
 let
-  version = "1.12";
+  version = "1.13";
 
   name = "xcb-proto-${version}";
 
   src = crossenv.nixpkgs.fetchurl {
     url = "https://xcb.freedesktop.org/dist/xcb-proto-${version}.tar.bz2";
-    sha256 = "01j91946q8f34l1mbvmmgvyc393sm28ym4lxlacpiav4qsjan8jr";
+    sha256 = "1qdxw9syhbvswiqj5dvj278lrmfhs81apzmvx6205s4vcqg7563v";
   };
 
   lib = crossenv.native.make_derivation rec {

--- a/nix/nixcrpkgs/pkgs/xorg-macros/builder.sh
+++ b/nix/nixcrpkgs/pkgs/xorg-macros/builder.sh
@@ -16,3 +16,7 @@ make install
 # The .pc files gets installed to /share/pkgconfig, but we want to see it in
 # /lib/pkgconfig.
 ln -s share $out/lib
+
+# xorg-macros.m4 uses AC_REQUIRE to pull in PKG_PROG_PKG_CONFIG, so pkg.m4
+# needs to be on the ACLOCAL_PATH.
+ln -s $pkgconfig/share/aclocal/* $out/share/aclocal/

--- a/nix/nixcrpkgs/pkgs/xorg-macros/default.nix
+++ b/nix/nixcrpkgs/pkgs/xorg-macros/default.nix
@@ -1,18 +1,19 @@
 { crossenv }:
 
 let
-  version = "1.19.1";
+  version = "1.19.2";
 
   name = "xorg-macros-${version}";
 
   src = crossenv.nixpkgs.fetchurl {
-    url = "https://www.x.org/releases/individual/util/util-macros-1.19.1.tar.gz";
-    sha256 = "1f27cmbxq0kdyvqsplxpsi9pxm5qy45lcagxr9gby2hy3pjd0aj7";
+    url = "https://www.x.org/releases/individual/util/util-macros-${version}.tar.gz";
+    sha256 = "1dvmkb0c12p94dn280kg9fm2nmpk6ramm9br36bsy3z67mfc89cj";
   };
 
   lib = crossenv.native.make_derivation {
     inherit version name src;
     builder = ./builder.sh;
+    pkgconfig = crossenv.nixpkgs.pkgconfig;
   };
 
   license = crossenv.native.make_derivation {

--- a/nix/nixcrpkgs/pkgs/xorgproto/builder.sh
+++ b/nix/nixcrpkgs/pkgs/xorgproto/builder.sh
@@ -1,0 +1,17 @@
+source $setup
+
+cp -r $src src
+chmod -R u+w src
+cd src
+autoreconf -v --install
+cd ..
+
+mkdir build
+cd build
+
+../src/configure --prefix=$out
+make
+make install
+
+mkdir $out/lib
+ln -s ../share/pkgconfig $out/lib/

--- a/nix/nixcrpkgs/pkgs/xorgproto/default.nix
+++ b/nix/nixcrpkgs/pkgs/xorgproto/default.nix
@@ -1,0 +1,38 @@
+{ crossenv, xorg-macros }:
+
+let
+  version = "2019-01-30";
+
+  name = "xorgproto-${version}";
+
+  src = crossenv.nixpkgs.fetchgit {
+    url = "https://anongit.freedesktop.org/git/xorg/proto/xorgproto";
+    rev = "a06b0e273420d34fe4c1fc0be50d3a5400e1545f";
+    sha256 = "0cck4c04wrix75nqc6gsa8yggasjgb1yi10ii8rj8wmzhzd83s21";
+  };
+
+  lib = crossenv.native.make_derivation rec {
+    inherit version name src;
+
+    builder = ./builder.sh;
+
+    native_inputs = [
+      crossenv.nixpkgs.autoconf
+      crossenv.nixpkgs.automake
+    ];
+
+    ACLOCAL_PATH = "${xorg-macros}/lib/aclocal";
+  };
+
+  license = crossenv.native.make_derivation {
+    name = "${name}-license";
+    inherit src;
+    builder = ./license_builder.sh;
+  };
+
+  license_set =
+    xorg-macros.license_set //
+    { "${name}" = license; };
+
+in
+  lib // { inherit license license_set; }

--- a/nix/nixcrpkgs/pkgs/xorgproto/license_builder.sh
+++ b/nix/nixcrpkgs/pkgs/xorgproto/license_builder.sh
@@ -1,0 +1,12 @@
+source $setup
+
+# Note: Concatenating license files like this is ugly.
+license=$(cat $src/COPYING*)
+
+cat > $out <<EOF
+<h2>xorgproto</h2>
+
+<pre>
+$license
+</pre>
+EOF

--- a/nix/nixcrpkgs/pkgs/zlib/builder.sh
+++ b/nix/nixcrpkgs/pkgs/zlib/builder.sh
@@ -5,9 +5,6 @@ tar -xf $src
 mkdir build
 cd build
 
-sed -i 's$Darwin. | darwin.$Ignore* | ignore*$' ../zlib-$version/configure
-
-CHOST=$host \
 ../zlib-$version/configure --prefix=$out --static
 
 make

--- a/nix/nixcrpkgs/pkgs/zlib/builder.sh
+++ b/nix/nixcrpkgs/pkgs/zlib/builder.sh
@@ -5,6 +5,9 @@ tar -xf $src
 mkdir build
 cd build
 
+sed -i 's$Darwin. | darwin.$Ignore* | ignore*$' ../zlib-$version/configure
+
+CHOST=$host \
 ../zlib-$version/configure --prefix=$out --static
 
 make

--- a/nix/nixcrpkgs/support/derivations.txt
+++ b/nix/nixcrpkgs/support/derivations.txt
@@ -7,20 +7,15 @@ define linux = linux32,linux64,linux-rpi
 mac.toolchain slow=1
 
 # Packages
-{$windows}.angle{,.examples} slow=1
-{$windows}.angle.examples
 omni.at-spi2-headers
 {$all}.avrdude
 omni.dejavu-fonts
 {$windows}.devcon
 {$all}.expat
-omni.fixesproto
+omni.xorgproto
 {$windows}.gdb
 {$all}.hello
 {$all}.hello_cpp
-omni.inputproto
-{$all}.ion
-omni.kbproto
 {$linux}.libudev
 {$all}.libusb
 {$all}.libusbp{,.examples}
@@ -31,6 +26,7 @@ omni.kbproto
 {$linux}.libxext
 {$linux}.libxfixes
 {$linux}.libxi
+{$linux}.libxkbcommon
 {$all}.openocd
 {$all}.pavr2
 {$windows}.pdcurses{,.examples}
@@ -46,9 +42,7 @@ omni.xcb-proto
 {$all}.xcb-util-keysyms
 {$all}.xcb-util-renderutil
 {$all}.xcb-util-wm
-omni.xextproto
 omni.xorg-macros
-{$all}.xproto
 omni.xtrans
 {$all}.zlib
 

--- a/nix/nixcrpkgs/support/derivations.txt
+++ b/nix/nixcrpkgs/support/derivations.txt
@@ -1,6 +1,6 @@
-define all = win32,win64,linux32,linux64,linux-rpi,mac
+define all = win32,win64,linux32,linux64,linux-aarch64,linux-rpi,mac
 define windows = win32,win64
-define linux = linux32,linux64,linux-rpi
+define linux = linux32,linux64,linux-aarch64,linux-rpi
 
 # Cross-compiler toolchains
 {$windows,$linux}.gcc slow=1

--- a/nix/nixcrpkgs/top.nix
+++ b/nix/nixcrpkgs/top.nix
@@ -1,4 +1,4 @@
-{ nixpkgs }:
+{ osx_sdk, nixpkgs }:
 
 rec {
   inherit nixpkgs;
@@ -18,7 +18,7 @@ rec {
       gcc_options = "--with-fpu=vfp --with-float=hard ";
     };
     aarch64-linux-musl = import ./linux { inherit native; arch = "aarch64"; };
-    macos = import ./macos { inherit native; };
+    macos = import ./macos { inherit osx_sdk native; };
   };
 
   pkgFun = crossenv: import ./pkgs.nix { inherit crossenv; } // crossenv;
@@ -85,7 +85,7 @@ rec {
 
   # gcroots is a derivation that builds a list of the items that we usually do
   # not want to garbage collect.
-  gcroots_func = env: env.default_native_inputs ++ [env.qt];	
+  gcroots_func = env: env.default_native_inputs ++ [env.qt];
   gcroots = native.make_derivation rec {
     name = "gcroots.txt";
     builder = ./file_builder.sh;

--- a/nix/nixcrpkgs/top.nix
+++ b/nix/nixcrpkgs/top.nix
@@ -1,4 +1,4 @@
-{ osx_sdk, nixpkgs }:
+{ nixpkgs }:
 
 rec {
   inherit nixpkgs;
@@ -18,7 +18,7 @@ rec {
       gcc_options = "--with-fpu=vfp --with-float=hard ";
     };
     aarch64-linux-musl = import ./linux { inherit native; arch = "aarch64"; };
-    macos = import ./macos { inherit osx_sdk native; };
+    macos = import ./macos { inherit native; };
   };
 
   pkgFun = crossenv: import ./pkgs.nix { inherit crossenv; } // crossenv;
@@ -31,6 +31,15 @@ rec {
   armv6-linux-musl = pkgFun crossenvs.armv6-linux-musl;
   aarch64-linux-musl = pkgFun crossenvs.aarch64-linux-musl;
   macos = pkgFun crossenvs.macos;
+
+  envs = [
+    i686-w64-mingw32
+    x86_64-w64-mingw32
+    i686-linux-musl
+    x86_64-linux-musl
+    armv6-linux-musl
+    macos
+  ];
 
   # omni is convenient name for packages that are used for cross-compiling but
   # are actually the same on all platforms.  You can just refer to it by
@@ -72,5 +81,18 @@ rec {
     builder = ./bundle_builder.sh;
     names = builtins.attrNames drvs;
     dirs = builtins.attrValues drvs;
+  };
+
+  # gcroots is a derivation that builds a list of the items that we usually do
+  # not want to garbage collect.
+  gcroots_func = env: env.default_native_inputs ++ [env.qt];	
+  gcroots = native.make_derivation rec {
+    name = "gcroots.txt";
+    builder = ./file_builder.sh;
+    contents = builtins.concatStringsSep "\n" (
+      builtins.foldl' (a: b: a ++ b) [] (
+        builtins.map gcroots_func envs
+      )
+    );
   };
 }

--- a/nix/nixcrpkgs/wrappers/builder.sh
+++ b/nix/nixcrpkgs/wrappers/builder.sh
@@ -1,0 +1,47 @@
+source $setup
+
+mkdir -p $out/bin
+
+cd $out
+
+cat > cmake_toolchain.txt <<EOF
+set(CMAKE_SYSTEM_NAME ${cmake_system})
+set(CMAKE_C_COMPILER ${host}-gcc)
+set(CMAKE_CXX_COMPILER ${host}-g++)
+set(CMAKE_RC_COMPILER ${host}-windres)
+EOF
+
+cat > meson_cross.txt <<END
+[binaries]
+c = '$host-gcc'
+cpp = '$host-g++'
+ar = '$host-ar'
+strip = '$host-strip'
+pkgconfig = 'pkg-config-cross'
+[host_machine]
+system = '$meson_system'
+cpu_family = '$meson_cpu_family'
+cpu = '$meson_cpu'
+endian = 'little'
+END
+
+cat > bin/pkg-config-cross <<EOF
+#!$(which bash)
+PKG_CONFIG_LIBDIR=\$PKG_CONFIG_CROSS_PATH \\
+PKG_CONFIG_PATH=\$PKG_CONFIG_CROSS_PATH \\
+exec pkg-config \$@
+EOF
+
+cat > bin/cmake-cross <<EOF
+#!$(which bash)
+PKG_CONFIG=pkg-config-cross \\
+CMAKE_PREFIX_PATH=\$CMAKE_CROSS_PREFIX_PATH \\
+exec cmake -DCMAKE_TOOLCHAIN_FILE=$out/cmake_toolchain.txt \$@
+EOF
+
+cat > bin/meson-cross <<EOF
+#!$(which bash)
+exec meson --cross-file $out/meson_cross.txt \$@
+EOF
+
+chmod a+x bin/*

--- a/nix/nixcrpkgs/wrappers/default.nix
+++ b/nix/nixcrpkgs/wrappers/default.nix
@@ -1,0 +1,9 @@
+# Note: We use shebang lines in the wrapper scripts only because Meson gives
+# an "exec format error" when it tries to run pkg-config-cross otherwise.
+
+env:
+env.native.make_derivation rec {
+  name = "cross-wrappers-${env.host}";
+  builder = ./builder.sh;
+  inherit (env) host cmake_system meson_system meson_cpu_family meson_cpu;
+}


### PR DESCRIPTION
Pulled in most recent pololu/nixcrpkgs while preserving urbit changes to macos building. Bumped musl to latest version to allow for static binaries to work on aarch64. Also changed openssl files to get it to build inside the nix sandbox.